### PR TITLE
fix(pub): uses relay deps that build on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   "author": "Relaying Services Team",
   "license": "MIT",
   "dependencies": {
-    "@rsksmart/rif-relay-client": "0.0.2-alpha.2",
-    "@rsksmart/rif-relay-contracts": "0.0.2-alpha.2",
-    "@rsksmart/rif-relay-common": "0.0.2-alpha.3",
+    "@rsksmart/rif-relay-client": "0.0.2-alpha.3",
+    "@rsksmart/rif-relay-contracts": "0.0.2-alpha.4",
+    "@rsksmart/rif-relay-common": "0.0.2-alpha.4",
     "@truffle/abi-utils": "~0.2.3",
     "@truffle/hdwallet-provider": "1.6.0",
     "@trufflesuite/web3-provider-engine": "15.0.13-1",


### PR DESCRIPTION
## What

-   updates rif relay dependencies to versions that build upon install

## Why

-   to allow automatic build for development and production

## Refs

- relates to https://rsklabs.atlassian.net/browse/PP-166
- source: https://www.npmjs.com/package/npmignore
