### PR TITLE
PP-462: Using loglevel from config file. 

### DIFF
--- a/server-config.json
+++ b/server-config.json
@@ -8,6 +8,6 @@
     "rskNodeUrl": "http://127.0.0.1:4444",
     "devMode": true,
     "customReplenish": false,
-    "logLevel": 1,
+    "logLevel": 2,
     "workdir": "/Users/borja/iovlabs/projects/rif-relay/environment"
 }

--- a/src/commands/Register.ts
+++ b/src/commands/Register.ts
@@ -31,6 +31,9 @@ export class Register extends CommandClient {
 
     async execute(options: RegisterOptions): Promise<void> {
         const transactions: string[] = [];
+        // TRACE: 0; DEBUG: 1; INFO: 2; WARN: 3; ERROR: 4; SILENT: 5;
+        log.setLevel(this.config.logLevel);
+        log.info('Log level: '+ log.getLevel());
         log.info(`Registering Enveloping relayer at ${options.relayUrl}`);
         log.info('Options received:', options);
         const response = await this.httpClient.getPingResponse(
@@ -143,7 +146,7 @@ export async function executeRegister(registerOptions?: RegisterOptions) {
     );
     const register = new Register(
         serverConfiguration.rskNodeUrl,
-        configure({ relayHubAddress: serverConfiguration.relayHubAddress }),
+        configure({ ...serverConfiguration } ),
         parameters.mnemonic
     );
     const portIncluded: boolean = serverConfiguration.url.indexOf(':') > 0;

--- a/src/commands/Register.ts
+++ b/src/commands/Register.ts
@@ -33,7 +33,7 @@ export class Register extends CommandClient {
         const transactions: string[] = [];
         // TRACE: 0; DEBUG: 1; INFO: 2; WARN: 3; ERROR: 4; SILENT: 5;
         log.setLevel(this.config.logLevel);
-        log.info('Log level: '+ log.getLevel());
+        log.info('Log level: ' + log.getLevel());
         log.info(`Registering Enveloping relayer at ${options.relayUrl}`);
         log.info('Options received:', options);
         const response = await this.httpClient.getPingResponse(
@@ -146,7 +146,7 @@ export async function executeRegister(registerOptions?: RegisterOptions) {
     );
     const register = new Register(
         serverConfiguration.rskNodeUrl,
-        configure({ ...serverConfiguration } ),
+        configure(serverConfiguration),
         parameters.mnemonic
     );
     const portIncluded: boolean = serverConfiguration.url.indexOf(':') > 0;


### PR DESCRIPTION
## What

Getting the loglevel form the config file. 

## Why

Although we’re using the loglevel library in the registration script, we aren’t setting the log level, so by default we cannot see what’s happening in the script. 

## Refs

[PP-462](https://rsklabs.atlassian.net/browse/PP-462)
