### PR TITLE
Fix: do not check that the fee receiver is a contract

### DIFF
--- a/src/ServerConfigParams.ts
+++ b/src/ServerConfigParams.ts
@@ -311,16 +311,6 @@ export async function resolveServerConfig(
         error(`RelayHub: no contract at address ${config.relayHubAddress}`);
     }
 
-    if (config.feesReceiver && config.feesReceiver !== constants.ZERO_ADDRESS) {
-        const isFeesReceiverDeployed =
-            await contractInteractor.isContractDeployed(config.feesReceiver);
-        if (!isFeesReceiverDeployed) {
-            error(
-                `FeesReceiver: no contract at address ${config.feesReceiver}`
-            );
-        }
-    }
-
     if (config.url == null) error('missing param: url');
     if (config.workdir == null) error('missing param: workdir');
     return { ...serverDefaultConfiguration, ...config };


### PR DESCRIPTION
## What

- Allow the fee receiver to be an EOA.

## Why

- Support the previous scenario, where the fee receiver was the worker address.

