### PR TITLE
PP-571/flexible-sponsorship

### DIFF
--- a/src/RelayServer.ts
+++ b/src/RelayServer.ts
@@ -419,7 +419,6 @@ export class RelayServer extends EventEmitter {
             );
         }
 
-
         if (!this.isSponsoredTx(req.relayRequest)) {
             const { feePercentage } = this.config;
 
@@ -487,17 +486,19 @@ export class RelayServer extends EventEmitter {
     isSponsoredTx(req: RelayRequest | DeployRequest): boolean {
         const { disableSponsoredTx, sponsoredDestinations } = this.config;
 
-        if(!disableSponsoredTx){
+        if (!disableSponsoredTx) {
             return true;
         }
 
-        if (sponsoredDestinations && sponsoredDestinations.includes(req.request.to)) {
+        if (
+            sponsoredDestinations &&
+            sponsoredDestinations.includes(req.request.to)
+        ) {
             return true;
         }
 
         return false;
     }
-
 
     async validateViewCallSucceeds(
         method: any,
@@ -517,7 +518,8 @@ export class RelayServer extends EventEmitter {
             );
         } catch (e) {
             throw new Error(
-                `relayCall (local call) reverted in server: ${(e as Error).message
+                `relayCall (local call) reverted in server: ${
+                    (e as Error).message
                 }`
             );
         }
@@ -537,7 +539,6 @@ export class RelayServer extends EventEmitter {
         );
 
         if (!this.isSponsoredTx(req.relayRequest)) {
-
             const { feePercentage } = this.config;
             log.debug(`RelayServer - feePercentage: ${feePercentage}`);
 
@@ -609,13 +610,13 @@ export class RelayServer extends EventEmitter {
 
         const method = isDeploy
             ? this.relayHubContract.contract.methods.deployCall(
-                req.relayRequest as DeployRequest,
-                req.metadata.signature
-            )
+                  req.relayRequest as DeployRequest,
+                  req.metadata.signature
+              )
             : this.relayHubContract.contract.methods.relayCall(
-                req.relayRequest as RelayRequest,
-                req.metadata.signature
-            );
+                  req.relayRequest as RelayRequest,
+                  req.metadata.signature
+              );
 
         // Call relayCall as a view function to see if we'll get paid for relaying this tx
         await this.validateViewCallSucceeds(method, req, maxPossibleGas);
@@ -903,7 +904,7 @@ latestBlock timestamp   | ${latestBlock.timestamp}
         if (
             this.alerted &&
             this.alertedBlock + this.config.alertedBlockDelay <
-            currentBlockNumber
+                currentBlockNumber
         ) {
             log.warn(
                 `Relay exited alerted state. Alerted block: ${this.alertedBlock}. Current block number: ${currentBlockNumber}`
@@ -971,7 +972,7 @@ latestBlock timestamp   | ${latestBlock.timestamp}
     _shouldRefreshState(currentBlock: number): boolean {
         return (
             currentBlock - this.lastRefreshBlock >=
-            this.config.refreshStateTimeoutBlocks || !this.isReady()
+                this.config.refreshStateTimeoutBlocks || !this.isReady()
         );
     }
 

--- a/src/RelayServer.ts
+++ b/src/RelayServer.ts
@@ -486,11 +486,8 @@ export class RelayServer extends EventEmitter {
     isSponsoredTx(req: RelayRequest | DeployRequest): boolean {
         const { disableSponsoredTx, sponsoredDestinations } = this.config;
 
-        if (!disableSponsoredTx) {
-            return true;
-        }
 
-        if (sponsoredDestinations.includes(req.request.to)) {
+        if (!disableSponsoredTx || sponsoredDestinations.includes(req.request.to)) {
             return true;
         }
 

--- a/src/RelayServer.ts
+++ b/src/RelayServer.ts
@@ -486,8 +486,10 @@ export class RelayServer extends EventEmitter {
     isSponsoredTx(req: RelayRequest | DeployRequest): boolean {
         const { disableSponsoredTx, sponsoredDestinations } = this.config;
 
-
-        if (!disableSponsoredTx || sponsoredDestinations.includes(req.request.to)) {
+        if (
+            !disableSponsoredTx ||
+            sponsoredDestinations.includes(req.request.to)
+        ) {
             return true;
         }
 

--- a/src/RelayServer.ts
+++ b/src/RelayServer.ts
@@ -490,10 +490,7 @@ export class RelayServer extends EventEmitter {
             return true;
         }
 
-        if (
-            sponsoredDestinations &&
-            sponsoredDestinations.includes(req.request.to)
-        ) {
+        if (sponsoredDestinations.includes(req.request.to)) {
             return true;
         }
 

--- a/src/ServerConfigParams.ts
+++ b/src/ServerConfigParams.ts
@@ -61,7 +61,7 @@ export interface ServerConfigParams {
      * @option false - The smart wallet of the relay user will be charged for the transaction
      * @option true - The relay worker will pay transaction gas.
      */
-    disableSponsoredTx: boolean;
+    disableSponsoredTx?: boolean;
 
     /**
      * Sets the fee value (%) that the server will take from all transactions.
@@ -71,9 +71,12 @@ export interface ServerConfigParams {
      * @note the minus sign is omitted if used
      * @note fractions exceeding the number of decimals of that of the native currency will be rounded up
      */
-    feePercentage: string;
+    feePercentage?: string;
 
-    sponsoredDestinations: Array<string>;
+    /**
+     * Destinations list that will make the relay worker pay for the transaction if @disableSponsoredTx is false
+     */
+    sponsoredDestinations?: Array<string>;
 }
 
 export interface ServerDependencies {
@@ -121,7 +124,8 @@ export const serverDefaultConfiguration: ServerConfigParams = {
     maxGasPrice: (100e9).toString(),
     estimateGasFactor: 1.2,
     disableSponsoredTx: false,
-    feePercentage: '0'
+    feePercentage: '0',
+    sponsoredDestinations: []
 };
 
 const ConfigParamsTypes = {

--- a/src/ServerConfigParams.ts
+++ b/src/ServerConfigParams.ts
@@ -61,7 +61,7 @@ export interface ServerConfigParams {
      * @option false - The smart wallet of the relay user will be charged for the transaction
      * @option true - The relay worker will pay transaction gas.
      */
-    disableSponsoredTx?: boolean;
+    disableSponsoredTx: boolean;
 
     /**
      * Sets the fee value (%) that the server will take from all transactions.
@@ -71,12 +71,12 @@ export interface ServerConfigParams {
      * @note the minus sign is omitted if used
      * @note fractions exceeding the number of decimals of that of the native currency will be rounded up
      */
-    feePercentage?: string;
+    feePercentage: string;
 
     /**
-     * Destinations list that will make the relay worker pay for the transaction if @disableSponsoredTx is false
+     * * List of destination contract addresses for which the transactions will be [sponsored](https://developers.rsk.co/rif/relay/architecture/#glossary)
      */
-    sponsoredDestinations?: Array<string>;
+    sponsoredDestinations: Array<string>;
 }
 
 export interface ServerDependencies {

--- a/src/ServerConfigParams.ts
+++ b/src/ServerConfigParams.ts
@@ -72,6 +72,8 @@ export interface ServerConfigParams {
      * @note fractions exceeding the number of decimals of that of the native currency will be rounded up
      */
     feePercentage: string;
+
+    sponsoredDestinations: Array<string>;
 }
 
 export interface ServerDependencies {

--- a/src/ServerConfigParams.ts
+++ b/src/ServerConfigParams.ts
@@ -160,7 +160,8 @@ const ConfigParamsTypes = {
     feesReceiver: 'string',
 
     disableSponsoredTx: 'boolean',
-    feePercentage: 'string'
+    feePercentage: 'string',
+    sponsoredDestinations: 'array'
 } as any;
 
 // by default: no waiting period - use VersionRegistry entries immediately.

--- a/test/unit/RelayServer.test.ts
+++ b/test/unit/RelayServer.test.ts
@@ -427,4 +427,46 @@ describe('RelayServer', () => {
             ).to.be.true;
         });
     });
+
+    describe('validateSponsorship', function () {
+
+        describe('disabledSponsoredTx(true)', function () {
+
+            let server: RelayServer;
+
+            beforeEach(function () {
+                server = new RelayServer({ disableSponsoredTx: true }, mockDependencies);
+            });
+
+            afterEach(function () {
+                restore();
+            });
+
+            it('shold not sponsor relay transaction', function () {
+                server.validateSponsorship();
+            });
+
+            it('shold not sponsor deploy transaction', function () {
+
+            });
+
+            it('should sponsor deploy transaction if its sponsored destination', function () {
+
+            });
+
+            it('should sponsor relay transaction if its sponsored destination', function () {
+
+            });
+        });
+
+        describe('disabledSponsoredTx(false)', function () {
+            it('should sponsor relay transaction', function () {
+
+            });
+
+            it('should sponsor deploy transaction', function () {
+
+            });
+        });
+    });
 });

--- a/test/unit/RelayServer.test.ts
+++ b/test/unit/RelayServer.test.ts
@@ -441,7 +441,7 @@ describe('RelayServer', () => {
         });
     });
 
-    describe('isSponsoredTx', function () {
+    describe('isSponsorshipAllowed', function () {
         const relayRequest: RelayRequest = {
             request: {
                 to: ''
@@ -470,7 +470,7 @@ describe('RelayServer', () => {
                 it('should not sponsor relay transactions if the destination contract address is not among the sponsored ones', function () {
                     relayRequest.request.to = '0x2';
                     expect(
-                        server.isSponsoredTx(relayRequest),
+                        server.isSponsorshipAllowed(relayRequest),
                         'Tx is sponsored'
                     ).to.be.false;
                 });
@@ -478,7 +478,7 @@ describe('RelayServer', () => {
                 it('should not sponsor deploy transactions if the destination contract address is not among the sponsored ones', function () {
                     deployRequest.request.to = '0x2';
                     expect(
-                        server.isSponsoredTx(deployRequest),
+                        server.isSponsorshipAllowed(deployRequest),
                         'Tx is sponsored'
                     ).to.be.false;
                 });
@@ -486,7 +486,7 @@ describe('RelayServer', () => {
                 it('should sponsor relay transactions if the destination contract address is among the sponsored ones', function () {
                     relayRequest.request.to = '0x1';
                     expect(
-                        server.isSponsoredTx(relayRequest),
+                        server.isSponsorshipAllowed(relayRequest),
                         'Tx is not sponsored'
                     ).to.be.true;
                 });
@@ -494,7 +494,7 @@ describe('RelayServer', () => {
                 it('should sponsor deploy transactions if the destination contract address is among the sponsored ones', function () {
                     deployRequest.request.to = '0x1';
                     expect(
-                        server.isSponsoredTx(deployRequest),
+                        server.isSponsorshipAllowed(deployRequest),
                         'Tx is not sponsored'
                     ).to.be.true;
                 });
@@ -508,8 +508,10 @@ describe('RelayServer', () => {
                     },
                     mockDependencies
                 );
-                expect(server.isSponsoredTx(deployRequest), 'Tx is sponsored')
-                    .to.be.false;
+                expect(
+                    server.isSponsorshipAllowed(deployRequest),
+                    'Tx is sponsored'
+                ).to.be.false;
             });
 
             it('should not sponsor transactions if sponsoredDestinations its empty', function () {
@@ -521,8 +523,10 @@ describe('RelayServer', () => {
                     },
                     mockDependencies
                 );
-                expect(server.isSponsoredTx(deployRequest), 'Tx is sponsored')
-                    .to.be.false;
+                expect(
+                    server.isSponsorshipAllowed(deployRequest),
+                    'Tx is sponsored'
+                ).to.be.false;
             });
 
             it('should sponsor transactions if the destination contract address is among the sponsored ones(multiple addresses)', function () {
@@ -536,11 +540,11 @@ describe('RelayServer', () => {
                     mockDependencies
                 );
                 expect(
-                    server.isSponsoredTx(deployRequest),
+                    server.isSponsorshipAllowed(deployRequest),
                     'Tx is not sponsored'
                 ).to.be.true;
                 expect(
-                    server.isSponsoredTx(relayRequest),
+                    server.isSponsorshipAllowed(relayRequest),
                     'Tx is not sponsored'
                 ).to.be.true;
             });
@@ -558,7 +562,7 @@ describe('RelayServer', () => {
             it('should sponsor relay transaction', function () {
                 relayRequest.request.to = '0x1';
                 expect(
-                    server.isSponsoredTx(relayRequest),
+                    server.isSponsorshipAllowed(relayRequest),
                     'Tx is not sponsored'
                 ).to.be.true;
             });
@@ -566,7 +570,7 @@ describe('RelayServer', () => {
             it('should sponsor deploy transaction', function () {
                 deployRequest.request.to = '0x1';
                 expect(
-                    server.isSponsoredTx(deployRequest),
+                    server.isSponsorshipAllowed(deployRequest),
                     'Tx is not sponsored'
                 ).to.be.true;
             });

--- a/test/unit/RelayServer.test.ts
+++ b/test/unit/RelayServer.test.ts
@@ -442,62 +442,105 @@ describe('RelayServer', () => {
     });
 
     describe('isSponsoredTx', function () {
+        const relayRequest: RelayRequest = {
+            request: {
+                to: ''
+            }
+        } as RelayRequest;
+        const deployRequest: DeployRequest = {
+            request: {
+                to: ''
+            }
+        } as DeployRequest;
+
         describe('disabledSponsoredTx(true)', function () {
             let server: RelayServer;
-            beforeEach(function () {
+
+            describe('', function () {
+                beforeEach(function () {
+                    server = new RelayServer(
+                        {
+                            disableSponsoredTx: true,
+                            sponsoredDestinations: ['0x1']
+                        },
+                        mockDependencies
+                    );
+                });
+
+                it('shold not sponsor relay transactions if the destination contract address is not among the sponsored ones', function () {
+                    relayRequest.request.to = '0x2';
+                    expect(
+                        server.isSponsoredTx(relayRequest),
+                        'Tx is sponsored'
+                    ).to.be.false;
+                });
+
+                it('shold not sponsor deploy transactions if the destination contract address is not among the sponsored ones', function () {
+                    deployRequest.request.to = '0x2';
+                    expect(
+                        server.isSponsoredTx(deployRequest),
+                        'Tx is sponsored'
+                    ).to.be.false;
+                });
+
+                it('should sponsor relay transactions if the destination contract address is among the sponsored ones', function () {
+                    relayRequest.request.to = '0x1';
+                    expect(
+                        server.isSponsoredTx(relayRequest),
+                        'Tx is not sponsored'
+                    ).to.be.true;
+                });
+
+                it('should sponsor deploy transactions if the destination contract address is among the sponsored ones', function () {
+                    deployRequest.request.to = '0x1';
+                    expect(
+                        server.isSponsoredTx(deployRequest),
+                        'Tx is not sponsored'
+                    ).to.be.true;
+                });
+            });
+
+            it('should not sponsor transactions if sponsoredDestinations its undefined', function () {
+                deployRequest.request.to = '0x1';
                 server = new RelayServer(
                     {
-                        disableSponsoredTx: true,
-                        sponsoredDestinations: ['0x1']
+                        disableSponsoredTx: true
                     },
                     mockDependencies
                 );
-            });
-
-            afterEach(function () {
-                restore();
-            });
-
-            it('shold not sponsor relay transaction', function () {
-                const relayRequest: RelayRequest = {
-                    request: {
-                        to: ''
-                    }
-                } as RelayRequest;
-                expect(server.isSponsoredTx(relayRequest), 'Tx is sponsored').to
-                    .be.false;
-            });
-
-            it('shold not sponsor deploy transaction', function () {
-                const deployRequest: DeployRequest = {
-                    request: {
-                        to: ''
-                    }
-                } as DeployRequest;
                 expect(server.isSponsoredTx(deployRequest), 'Tx is sponsored')
                     .to.be.false;
             });
 
-            it('should sponsor relay transaction if its sponsored destination', function () {
-                const relayRequest: RelayRequest = {
-                    request: {
-                        to: '0x1'
-                    }
-                } as RelayRequest;
-                expect(
-                    server.isSponsoredTx(relayRequest),
-                    'Tx is not sponsored'
-                ).to.be.true;
+            it('should not sponsor transactions if sponsoredDestinations its empty', function () {
+                deployRequest.request.to = '0x1';
+                server = new RelayServer(
+                    {
+                        disableSponsoredTx: true,
+                        sponsoredDestinations: []
+                    },
+                    mockDependencies
+                );
+                expect(server.isSponsoredTx(deployRequest), 'Tx is sponsored')
+                    .to.be.false;
             });
 
-            it('should sponsor deploy transaction if its sponsored destination', function () {
-                const deployRequest: DeployRequest = {
-                    request: {
-                        to: '0x1'
-                    }
-                } as DeployRequest;
+            it('should sponsor transactions if the destination contract address is among the sponsored ones(multiple addresses)', function () {
+                relayRequest.request.to = '0x1';
+                deployRequest.request.to = '0x2';
+                server = new RelayServer(
+                    {
+                        disableSponsoredTx: true,
+                        sponsoredDestinations: ['0x1', '0x2']
+                    },
+                    mockDependencies
+                );
                 expect(
                     server.isSponsoredTx(deployRequest),
+                    'Tx is not sponsored'
+                ).to.be.true;
+                expect(
+                    server.isSponsoredTx(relayRequest),
                     'Tx is not sponsored'
                 ).to.be.true;
             });
@@ -505,17 +548,6 @@ describe('RelayServer', () => {
 
         describe('disabledSponsoredTx(false)', function () {
             let server: RelayServer;
-            const relayRequest: RelayRequest = {
-                request: {
-                    to: ''
-                }
-            } as RelayRequest;
-            const deployRequest: DeployRequest = {
-                request: {
-                    to: ''
-                }
-            } as DeployRequest;
-
             beforeEach(function () {
                 server = new RelayServer(
                     { disableSponsoredTx: false },
@@ -524,6 +556,7 @@ describe('RelayServer', () => {
             });
 
             it('should sponsor relay transaction', function () {
+                relayRequest.request.to = '0x1';
                 expect(
                     server.isSponsoredTx(relayRequest),
                     'Tx is not sponsored'
@@ -531,6 +564,7 @@ describe('RelayServer', () => {
             });
 
             it('should sponsor deploy transaction', function () {
+                deployRequest.request.to = '0x1';
                 expect(
                     server.isSponsoredTx(deployRequest),
                     'Tx is not sponsored'

--- a/test/unit/RelayServer.test.ts
+++ b/test/unit/RelayServer.test.ts
@@ -4,7 +4,7 @@ import {
     RelayMetadata,
     RelayTransactionRequest
 } from '@rsksmart/rif-relay-common';
-import { ForwardRequest, RelayData } from '@rsksmart/rif-relay-contracts';
+import { DeployRequest, ForwardRequest, RelayData, RelayRequest } from '@rsksmart/rif-relay-contracts';
 import {
     ERC20Instance,
     IRelayHubInstance
@@ -428,14 +428,14 @@ describe('RelayServer', () => {
         });
     });
 
-    describe('validateSponsorship', function () {
+
+    describe('isSponsoredTx', function () {
 
         describe('disabledSponsoredTx(true)', function () {
 
             let server: RelayServer;
-
             beforeEach(function () {
-                server = new RelayServer({ disableSponsoredTx: true }, mockDependencies);
+                server = new RelayServer({ disableSponsoredTx: true, sponsoredDestinations: ['0x1'] }, mockDependencies);
             });
 
             afterEach(function () {
@@ -443,30 +443,67 @@ describe('RelayServer', () => {
             });
 
             it('shold not sponsor relay transaction', function () {
-                server.validateSponsorship();
+                const relayRequest: RelayRequest = { 
+                    request: {
+                        to: ''
+                    }
+                 } as RelayRequest;
+                expect(server.isSponsoredTx(relayRequest)).to.be.false;
             });
 
             it('shold not sponsor deploy transaction', function () {
-
-            });
-
-            it('should sponsor deploy transaction if its sponsored destination', function () {
-
+                const deployRequest: DeployRequest = {
+                    request: {
+                        to: ''
+                    }
+                } as DeployRequest;
+                expect(server.isSponsoredTx(deployRequest)).to.be.false;
             });
 
             it('should sponsor relay transaction if its sponsored destination', function () {
+                const relayRequest: RelayRequest = { 
+                    request: {
+                        to: '0x1'
+                    }
+                 } as RelayRequest;
+                expect(server.isSponsoredTx(relayRequest)).to.be.true;
+            });
 
+            it('should sponsor deploy transaction if its sponsored destination', function () {
+                const deployRequest: DeployRequest = {
+                    request: {
+                        to: '0x1'
+                    }
+                } as DeployRequest;
+                expect(server.isSponsoredTx(deployRequest)).to.be.true;
             });
         });
 
         describe('disabledSponsoredTx(false)', function () {
-            it('should sponsor relay transaction', function () {
+            let server: RelayServer;
+            const relayRequest: RelayRequest = { 
+                request: {
+                    to: ''
+                }
+             } as RelayRequest;
+            const deployRequest: DeployRequest = {
+                request: {
+                    to: ''
+                }
+            } as DeployRequest;
 
+            beforeEach(function(){
+                server = new RelayServer({ disableSponsoredTx: false }, mockDependencies);
+            });
+
+            it('should sponsor relay transaction', function () {
+                expect(server.isSponsoredTx(relayRequest)).to.be.true;
             });
 
             it('should sponsor deploy transaction', function () {
-
+                expect(server.isSponsoredTx(deployRequest)).to.be.true;
             });
         });
     });
+
 });

--- a/test/unit/RelayServer.test.ts
+++ b/test/unit/RelayServer.test.ts
@@ -467,7 +467,7 @@ describe('RelayServer', () => {
                     );
                 });
 
-                it('shold not sponsor relay transactions if the destination contract address is not among the sponsored ones', function () {
+                it('should not sponsor relay transactions if the destination contract address is not among the sponsored ones', function () {
                     relayRequest.request.to = '0x2';
                     expect(
                         server.isSponsoredTx(relayRequest),
@@ -475,7 +475,7 @@ describe('RelayServer', () => {
                     ).to.be.false;
                 });
 
-                it('shold not sponsor deploy transactions if the destination contract address is not among the sponsored ones', function () {
+                it('should not sponsor deploy transactions if the destination contract address is not among the sponsored ones', function () {
                     deployRequest.request.to = '0x2';
                     expect(
                         server.isSponsoredTx(deployRequest),

--- a/test/unit/RelayServer.test.ts
+++ b/test/unit/RelayServer.test.ts
@@ -4,7 +4,12 @@ import {
     RelayMetadata,
     RelayTransactionRequest
 } from '@rsksmart/rif-relay-common';
-import { DeployRequest, ForwardRequest, RelayData, RelayRequest } from '@rsksmart/rif-relay-contracts';
+import {
+    DeployRequest,
+    ForwardRequest,
+    RelayData,
+    RelayRequest
+} from '@rsksmart/rif-relay-contracts';
 import {
     ERC20Instance,
     IRelayHubInstance
@@ -428,14 +433,17 @@ describe('RelayServer', () => {
         });
     });
 
-
     describe('isSponsoredTx', function () {
-
         describe('disabledSponsoredTx(true)', function () {
-
             let server: RelayServer;
             beforeEach(function () {
-                server = new RelayServer({ disableSponsoredTx: true, sponsoredDestinations: ['0x1'] }, mockDependencies);
+                server = new RelayServer(
+                    {
+                        disableSponsoredTx: true,
+                        sponsoredDestinations: ['0x1']
+                    },
+                    mockDependencies
+                );
             });
 
             afterEach(function () {
@@ -443,11 +451,11 @@ describe('RelayServer', () => {
             });
 
             it('shold not sponsor relay transaction', function () {
-                const relayRequest: RelayRequest = { 
+                const relayRequest: RelayRequest = {
                     request: {
                         to: ''
                     }
-                 } as RelayRequest;
+                } as RelayRequest;
                 expect(server.isSponsoredTx(relayRequest)).to.be.false;
             });
 
@@ -461,11 +469,11 @@ describe('RelayServer', () => {
             });
 
             it('should sponsor relay transaction if its sponsored destination', function () {
-                const relayRequest: RelayRequest = { 
+                const relayRequest: RelayRequest = {
                     request: {
                         to: '0x1'
                     }
-                 } as RelayRequest;
+                } as RelayRequest;
                 expect(server.isSponsoredTx(relayRequest)).to.be.true;
             });
 
@@ -481,19 +489,22 @@ describe('RelayServer', () => {
 
         describe('disabledSponsoredTx(false)', function () {
             let server: RelayServer;
-            const relayRequest: RelayRequest = { 
+            const relayRequest: RelayRequest = {
                 request: {
                     to: ''
                 }
-             } as RelayRequest;
+            } as RelayRequest;
             const deployRequest: DeployRequest = {
                 request: {
                     to: ''
                 }
             } as DeployRequest;
 
-            beforeEach(function(){
-                server = new RelayServer({ disableSponsoredTx: false }, mockDependencies);
+            beforeEach(function () {
+                server = new RelayServer(
+                    { disableSponsoredTx: false },
+                    mockDependencies
+                );
             });
 
             it('should sponsor relay transaction', function () {
@@ -505,5 +516,4 @@ describe('RelayServer', () => {
             });
         });
     });
-
 });


### PR DESCRIPTION
## What

- Sponsor all
- Sponsor none
- Sponsor smart wallet creation, But not the transactions on the smart wallet
- Sponsor transactions for certain destination addresses (ex: sponsored deployment and also sponsored RNS request and RNS registration)

## Why

- More flexibility for the server

## Refs

-   [PP-571](https://rsklabs.atlassian.net/browse/PP-571)
