### PR TITLE
Add CD for rif-wallet-testnet environment

### DIFF
--- a/.github/workflows/deploy.qa.yml
+++ b/.github/workflows/deploy.qa.yml
@@ -30,4 +30,4 @@ jobs:
                       --document-name "AWS-RunRemoteScript" \
                       --instance-ids "${{ secrets.QA_EC2_ID }}" \
                       --region=${{ secrets.QA_AWS_REGION }} \
-                      --parameters '{"sourceType":["GitHub"],"sourceInfo":["{\"owner\":\"rootstock\", \"repository\":\"ask-devops\", \"path\": \"rif-relay/qa/\", \"tokenInfo\":\"{{ssm-secure:github-token}}\"}"],"commandLine":["deploy-rifrelay.sh"]}'
+                      --parameters '{"sourceType":["GitHub"],"sourceInfo":["{\"owner\":\"rootstock\", \"repository\":\"ask-devops\", \"path\": \"rif-relay/\", \"tokenInfo\":\"{{ssm-secure:github-token}}\"}"],"commandLine":["deploy-qa.sh"]}'

--- a/.github/workflows/deploy.rwt.yml
+++ b/.github/workflows/deploy.rwt.yml
@@ -3,9 +3,8 @@ name: CD for RIF-Wallet-Testnet
 
 on:
     push:
-        branches: [master, PP-612/rif-wallet-testnet-cd]
-        # tags:
-        #     - '**beta-rifwallet**'
+        tags:
+            - '**beta-rifwallet**'
 
 jobs:
     deploy-qa:

--- a/.github/workflows/deploy.rwt.yml
+++ b/.github/workflows/deploy.rwt.yml
@@ -1,9 +1,11 @@
 ---
-name: CD for QA
+name: CD for RIF-Wallet-Testnet
 
 on:
     push:
-        branches: [master]
+        branches: [master, PP-612/rif-wallet-testnet-cd]
+        tags:
+            - '**beta-rifwallet**'
 
 jobs:
     deploy-qa:
@@ -30,4 +32,4 @@ jobs:
                       --document-name "AWS-RunRemoteScript" \
                       --instance-ids "${{ secrets.QA_EC2_ID }}" \
                       --region=${{ secrets.QA_AWS_REGION }} \
-                      --parameters '{"sourceType":["GitHub"],"sourceInfo":["{\"owner\":\"rootstock\", \"repository\":\"ask-devops\", \"path\": \"rif-relay/qa/\", \"tokenInfo\":\"{{ssm-secure:github-token}}\"}"],"commandLine":["deploy-rifrelay.sh"]}'
+                      --parameters '{"sourceType":["GitHub"],"sourceInfo":["{\"owner\":\"rootstock\", \"repository\":\"ask-devops\", \"path\": \"rif-relay/rif-wallet-testnet/\", \"tokenInfo\":\"{{ssm-secure:github-token}}\"}"],"commandLine":["deploy-rifrelay.sh"]}'

--- a/.github/workflows/deploy.rwt.yml
+++ b/.github/workflows/deploy.rwt.yml
@@ -29,6 +29,6 @@ jobs:
               run: |
                   aws ssm send-command \
                       --document-name "AWS-RunRemoteScript" \
-                      --instance-ids "${{ secrets.QA_EC2_ID }}" \
+                      --instance-ids "i-077a12f03f753e342" \
                       --region=${{ secrets.QA_AWS_REGION }} \
                       --parameters '{"sourceType":["GitHub"],"sourceInfo":["{\"owner\":\"rootstock\", \"repository\":\"ask-devops\", \"path\": \"rif-relay/\", \"tokenInfo\":\"{{ssm-secure:github-token}}\"}"],"commandLine":["deploy-rwt.sh"]}'

--- a/.github/workflows/deploy.rwt.yml
+++ b/.github/workflows/deploy.rwt.yml
@@ -4,8 +4,8 @@ name: CD for RIF-Wallet-Testnet
 on:
     push:
         branches: [master, PP-612/rif-wallet-testnet-cd]
-        tags:
-            - '**beta-rifwallet**'
+        # tags:
+        #     - '**beta-rifwallet**'
 
 jobs:
     deploy-qa:
@@ -32,4 +32,4 @@ jobs:
                       --document-name "AWS-RunRemoteScript" \
                       --instance-ids "${{ secrets.QA_EC2_ID }}" \
                       --region=${{ secrets.QA_AWS_REGION }} \
-                      --parameters '{"sourceType":["GitHub"],"sourceInfo":["{\"owner\":\"rootstock\", \"repository\":\"ask-devops\", \"path\": \"rif-relay/rif-wallet-testnet/\", \"tokenInfo\":\"{{ssm-secure:github-token}}\"}"],"commandLine":["deploy-rifrelay.sh"]}'
+                      --parameters '{"sourceType":["GitHub"],"sourceInfo":["{\"owner\":\"rootstock\", \"repository\":\"ask-devops\", \"path\": \"rif-relay/\", \"tokenInfo\":\"{{ssm-secure:github-token}}\"}"],"commandLine":["deploy-rwt.sh"]}'

--- a/.github/workflows/deploy.rwt.yml
+++ b/.github/workflows/deploy.rwt.yml
@@ -7,10 +7,10 @@ on:
             - '**beta-rifwallet**'
 
 jobs:
-    deploy-qa:
+    deploy-rif-wallet-testnet:
         runs-on: ubuntu-latest
         environment:
-            name: QA
+            name: RIF-Wallet-Testnet
 
         steps:
             - name: Checkout
@@ -21,14 +21,14 @@ jobs:
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v1
               with:
-                  aws-access-key-id: ${{ secrets.QA_AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.QA_AWS_SECRET_ACCESS_KEY }}
-                  aws-region: ${{ secrets.QA_AWS_REGION }}
+                  aws-access-key-id: ${{ secrets.RWT_AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.RWT_AWS_SECRET_ACCESS_KEY }}
+                  aws-region: ${{ secrets.RWT_AWS_REGION }}
 
-            - name: Deploy rif-relay-server on QA
+            - name: Deploy rif-relay-server on RWT
               run: |
                   aws ssm send-command \
                       --document-name "AWS-RunRemoteScript" \
-                      --instance-ids "i-077a12f03f753e342" \
-                      --region=${{ secrets.QA_AWS_REGION }} \
+                      --instance-ids ""${{ secrets.RWT_EC2_ID }}"" \
+                      --region=${{ secrets.RWT_AWS_REGION }} \
                       --parameters '{"sourceType":["GitHub"],"sourceInfo":["{\"owner\":\"rootstock\", \"repository\":\"ask-devops\", \"path\": \"rif-relay/\", \"tokenInfo\":\"{{ssm-secure:github-token}}\"}"],"commandLine":["deploy-rwt.sh"]}'

--- a/docker-compose-rwt.yml
+++ b/docker-compose-rwt.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+    rif-relay:
+        build:
+            context: .
+        entrypoint: 'node dist/commands/Start.js --config server-config.rwt.json'
+        ports:
+            - '8090:8090'
+        volumes:
+            - './environment:/srv/app/environment'

--- a/server-config.rwt.json
+++ b/server-config.rwt.json
@@ -1,0 +1,16 @@
+{
+    "url": "https://backend.rif-wallet-testnet.relay.rifcomputing.net",
+    "port": 8090,
+    "relayHubAddress": "0x2d4c018C6c9ad4487D7A4b0829A1f20246D9f5Ad",
+    "relayVerifierAddress": "0x36cEd034CaEc41cD4f19949B5BbeB52f091bbC77",
+    "deployVerifierAddress": "0x1A92e1061791658dA9dCF94749de317B86F341A4",
+    "feesReceiver": "0xcf243FB47B0DCDB66680a7307006d9f94A65f82C",
+    "gasPriceFactor": 1,
+    "rskNodeUrl": "http://172.17.0.1:4444",
+    "devMode": true,
+    "customReplenish": false,
+    "feePercentage": "0",
+    "disableSponsoredTx": false,
+    "logLevel": 0,
+    "workdir": "/srv/app/environment"
+}


### PR DESCRIPTION
Since we created a dedicated environment in TESTNET for the RIF Wallet, this is the CD to automatically deploy there. 
This CD associateS the deployment to a release creation having a specific tag format (e.g. vX.Y.Z-beta-rifwalet.W , where the fixed part is represented by **beta-rifwallet**). We want to make sure that this release doesn’t affect the other testnet release and viceversa.

E.g.:

If we create a tag v1.0.0-beta.x it must be released to TESTNET only (not RIF Wallet); if we create a tag v1.0.0-beta-rifwallet.x it must be released to RIF Wallet testnet only.