### PR TITLE
Configure the CD in the Server to deploy to RIF TESTNET environment

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,41 +1,41 @@
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
-  schedule:
-    - cron: "56 1 * * 5"
+    push:
+        branches: ['master']
+    pull_request:
+        branches: ['master']
+    schedule:
+        - cron: '56 1 * * 5'
 
 jobs:
-  analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
+    analyze:
+        name: Analyze
+        runs-on: ubuntu-latest
+        permissions:
+            actions: read
+            contents: read
+            security-events: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ javascript ]
+        strategy:
+            fail-fast: false
+            matrix:
+                language: [javascript]
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
-        with:
-          languages: ${{ matrix.language }}
-          queries: +security-and-quality
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v2
+              with:
+                  languages: ${{ matrix.language }}
+                  queries: +security-and-quality
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+            - name: Autobuild
+              uses: github/codeql-action/autobuild@v2
 
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
-        with:
-          category: "/language:${{ matrix.language }}"
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@v2
+              with:
+                  category: '/language:${{ matrix.language }}'

--- a/.github/workflows/deploy.testnet.yml
+++ b/.github/workflows/deploy.testnet.yml
@@ -1,0 +1,34 @@
+---
+name: CD for Testnet
+
+on:
+    push:
+        tags:
+            - '**beta-testnet**'
+
+jobs:
+    deploy-testnet:
+        runs-on: ubuntu-latest
+        environment:
+            name: Testnet
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v1
+              with:
+                  aws-access-key-id: ${{ secrets.TESTNET_AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.TESTNET_AWS_SECRET_ACCESS_KEY }}
+                  aws-region: ${{ secrets.TESTNET_AWS_REGION }}
+
+            - name: Deploy rif-relay-server on TESTNET
+              run: |
+                  aws ssm send-command \
+                      --document-name "AWS-RunRemoteScript" \
+                      --instance-ids ""${{ secrets.TESTNET_EC2_ID }}"" \
+                      --region=${{ secrets.TESTNET_AWS_REGION }} \
+                      --parameters '{"sourceType":["GitHub"],"sourceInfo":["{\"owner\":\"rootstock\", \"repository\":\"ask-devops\", \"path\": \"rif-relay/\", \"tokenInfo\":\"{{ssm-secure:github-token}}\"}"],"commandLine":["deploy-TESTNET.sh"]}'

--- a/.github/workflows/deploy.testnet.yml
+++ b/.github/workflows/deploy.testnet.yml
@@ -31,4 +31,4 @@ jobs:
                       --document-name "AWS-RunRemoteScript" \
                       --instance-ids ""${{ secrets.TESTNET_EC2_ID }}"" \
                       --region=${{ secrets.TESTNET_AWS_REGION }} \
-                      --parameters '{"sourceType":["GitHub"],"sourceInfo":["{\"owner\":\"rootstock\", \"repository\":\"ask-devops\", \"path\": \"rif-relay/\", \"tokenInfo\":\"{{ssm-secure:github-token}}\"}"],"commandLine":["deploy-TESTNET.sh"]}'
+                      --parameters '{"sourceType":["GitHub"],"sourceInfo":["{\"owner\":\"rootstock\", \"repository\":\"ask-devops\", \"path\": \"rif-relay/\", \"tokenInfo\":\"{{ssm-secure:github-token}}\"}"],"commandLine":["deploy-testnet.sh"]}'


### PR DESCRIPTION
This PR is to configure the server to automatically deploy in the public testnet environment.  The deployment is triggered when a release is created having a specific a tag format (e.g. vX.Y.Z-beta-testnet.W ). We want to make sure that this release doesn’t affect the other testnet release and viceversa.

E.g.:

If we create a tag v1.0.0-beta-testnet.x it must be released to TESTNET only (not RIF Wallet); if we create a tag v1.0.0-beta-rifwallet.x it must be released to RIF Wallet testnet only.

https://rsklabs.atlassian.net/browse/PP-623