### PR TITLE
Fix: remove fee receiver from rwt

### DIFF
--- a/server-config.rwt.json
+++ b/server-config.rwt.json
@@ -4,7 +4,6 @@
     "relayHubAddress": "0xAd525463961399793f8716b0D85133ff7503a7C2",
     "relayVerifierAddress": "0x5897E84216220663F306676458Afc7bf2A6A3C52",
     "deployVerifierAddress": "0xAe59e767768c6c25d64619Ee1c498Fd7D83e3c24",
-    "feesReceiver": "0x52D107bB12d83EbCBFb4A6Ad0ec866Bb69FdB5Db",
     "gasPriceFactor": 1,
     "rskNodeUrl": "http://172.17.0.1:4444",
     "devMode": true,


### PR DESCRIPTION
## What

-  Remove fee receiver from RWT configuration

## Why

- Fee receiver isn't required in RWT