### PR TITLE
PP-779: fix expiration date logged on v1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rif-relay-server",
-  "version": "1.0.1-beta-rifwallet.6",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rif-relay-server",
-      "version": "1.0.1-beta-rifwallet.6",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@openzeppelin/test-helpers": "^0.5.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rif-relay-server",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.1-beta-rifwallet.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rif-relay-server",
-      "version": "1.0.0-alpha.4",
+      "version": "1.0.1-beta-rifwallet.6",
       "license": "MIT",
       "dependencies": {
         "@openzeppelin/test-helpers": "^0.5.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rif-relay-server",
-  "version": "1.0.1-beta-rifwallet.6",
+  "version": "1.0.1",
   "description": "This project contains all the server code for the rif relay system.",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rif-relay-server",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.1-beta-rifwallet.6",
   "description": "This project contains all the server code for the rif relay system.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/RelayServer.utils.ts
+++ b/src/RelayServer.utils.ts
@@ -4,8 +4,9 @@ export function secondsToDate(dateInSeconds: number) {
 
 export const expiredTimeErrorMessage = (
     requestExpirationDate: Date,
-    minimumAcceptableDate: Date) => 
-        `Request expired (or too close): expiration date received "${requestExpirationDate.toUTCString()}" is expected to be greater than or equal to "${minimumAcceptableDate.toUTCString()}"`
+    minimumAcceptableDate: Date
+) =>
+    `Request expired (or too close): expiration date received "${requestExpirationDate.toUTCString()}" is expected to be greater than or equal to "${minimumAcceptableDate.toUTCString()}"`;
 
 export async function validateExpirationTime(
     validUntilTime: string,

--- a/src/RelayServer.utils.ts
+++ b/src/RelayServer.utils.ts
@@ -1,0 +1,26 @@
+export function secondsToDate(dateInSeconds: number) {
+    return new Date(dateInSeconds * 1000);
+}
+
+export const expiredTimeErrorMessage = (
+    requestExpirationDate: Date,
+    minimumAcceptableDate: Date) => 
+        `Request expired (or too close): expiration date received "${requestExpirationDate.toUTCString()}" is expected to be greater than or equal to "${minimumAcceptableDate.toUTCString()}"`
+
+export async function validateExpirationTime(
+    validUntilTime: string,
+    requestMinValidSeconds: number
+) {
+    const parsedValidUntilTime = parseInt(validUntilTime);
+    const secondsNow = Math.round(Date.now() / 1000);
+    const expiredInSeconds = parsedValidUntilTime - secondsNow;
+    if (expiredInSeconds < requestMinValidSeconds) {
+        const expirationDate = secondsToDate(parsedValidUntilTime);
+        const minimumAcceptableDate = secondsToDate(
+            secondsNow + requestMinValidSeconds
+        );
+        throw new Error(
+            expiredTimeErrorMessage(expirationDate, minimumAcceptableDate)
+        );
+    }
+}

--- a/test/unit/RelayServer.test.ts
+++ b/test/unit/RelayServer.test.ts
@@ -44,7 +44,10 @@ import {
     INSUFFICIENT_TOKEN_AMOUNT
 } from '../../src/definitions/errorMessages.const';
 import ExchangeToken from '../../src/definitions/token.type';
-import { expiredTimeErrorMessage, secondsToDate } from '../../src/RelayServer.utils';
+import {
+    expiredTimeErrorMessage,
+    secondsToDate
+} from '../../src/RelayServer.utils';
 
 use(sinonChai);
 use(chaiAsPromised);
@@ -348,7 +351,9 @@ describe('RelayServer', () => {
                 address: fakeRelayHubAddress
             } as IRelayHubInstance;
 
-            await expect(server.validateInput(fakeRelayTransactionRequest)).to.be.rejectedWith(
+            await expect(
+                server.validateInput(fakeRelayTransactionRequest)
+            ).to.be.rejectedWith(
                 `Wrong fees receiver address: ${fakeFeesReceiverAddress}\n`
             );
         });
@@ -369,19 +374,31 @@ describe('RelayServer', () => {
             server.relayHubContract = {
                 address: fakeRelayHubAddress
             } as IRelayHubInstance;
-            fakeRelayTransactionRequest.relayRequest.request.validUntilTime = (Math.round(now / 1000) - 1).toString();
-            
-            const expirationDate = secondsToDate(
-                parseInt(fakeRelayTransactionRequest.relayRequest.request.validUntilTime));
-            const minimumAcceptableDate =  secondsToDate(
-                (Math.round(Date.now() / 1000) + requestMinValidSecondsConfig)
-            );
-            console.log(expirationDate.toUTCString(), minimumAcceptableDate.toUTCString());
-            const expectedError = expiredTimeErrorMessage(expirationDate, minimumAcceptableDate);
+            fakeRelayTransactionRequest.relayRequest.request.validUntilTime = (
+                Math.round(now / 1000) - 1
+            ).toString();
 
-            await expect(server.validateInput(fakeRelayTransactionRequest)).to.be.rejectedWith(
-                expectedError
+            const expirationDate = secondsToDate(
+                parseInt(
+                    fakeRelayTransactionRequest.relayRequest.request
+                        .validUntilTime
+                )
             );
+            const minimumAcceptableDate = secondsToDate(
+                Math.round(Date.now() / 1000) + requestMinValidSecondsConfig
+            );
+            console.log(
+                expirationDate.toUTCString(),
+                minimumAcceptableDate.toUTCString()
+            );
+            const expectedError = expiredTimeErrorMessage(
+                expirationDate,
+                minimumAcceptableDate
+            );
+
+            await expect(
+                server.validateInput(fakeRelayTransactionRequest)
+            ).to.be.rejectedWith(expectedError);
             clock.restore();
         });
 
@@ -401,19 +418,28 @@ describe('RelayServer', () => {
             server.relayHubContract = {
                 address: fakeRelayHubAddress
             } as IRelayHubInstance;
-            fakeRelayTransactionRequest.relayRequest.request.validUntilTime = (Math.round(now / 1000) + (requestMinValidSecondsConfig - 1)).toString();
+            fakeRelayTransactionRequest.relayRequest.request.validUntilTime = (
+                Math.round(now / 1000) +
+                (requestMinValidSecondsConfig - 1)
+            ).toString();
 
-            
             const expirationDate = secondsToDate(
-                parseInt(fakeRelayTransactionRequest.relayRequest.request.validUntilTime));
-            const minimumAcceptableDate =  secondsToDate(
-                (Math.round(Date.now() / 1000) + requestMinValidSecondsConfig)
+                parseInt(
+                    fakeRelayTransactionRequest.relayRequest.request
+                        .validUntilTime
+                )
             );
-            const expectedError = expiredTimeErrorMessage(expirationDate, minimumAcceptableDate);
+            const minimumAcceptableDate = secondsToDate(
+                Math.round(Date.now() / 1000) + requestMinValidSecondsConfig
+            );
+            const expectedError = expiredTimeErrorMessage(
+                expirationDate,
+                minimumAcceptableDate
+            );
 
-            await expect(server.validateInput(fakeRelayTransactionRequest)).to.be.rejectedWith(
-                expectedError
-            );
+            await expect(
+                server.validateInput(fakeRelayTransactionRequest)
+            ).to.be.rejectedWith(expectedError);
             clock.restore();
         });
 
@@ -433,9 +459,12 @@ describe('RelayServer', () => {
             server.relayHubContract = {
                 address: fakeRelayHubAddress
             } as IRelayHubInstance;
-            fakeRelayTransactionRequest.relayRequest.request.validUntilTime = (Math.round(now / 1000) + 60).toString();
+            fakeRelayTransactionRequest.relayRequest.request.validUntilTime = (
+                Math.round(now / 1000) + 60
+            ).toString();
 
-            await expect(server.validateInput(fakeRelayTransactionRequest)).not.to.be.rejected;
+            await expect(server.validateInput(fakeRelayTransactionRequest)).not
+                .to.be.rejected;
             clock.restore();
         });
     });


### PR DESCRIPTION
## What

- Fix the time logged when the request expiration time is expired or about to expire.

## Why

- The minimum acceptable time is wrongly logged.
