### PR TITLE
fix(RREL-013): improve key creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "register": "ts-node src/commands/Register.ts",
     "start": "ts-node src/commands/Start.ts",
     "tdd": "npm run test -- --watch --watch-files src,test",
-    "test": "ALLOW_CONFIG_MUTATIONS=true  npx mocha -r ts-node/register --extensions ts 'test/**/*.{test,spec}.ts'"
+    "test": "ALLOW_CONFIG_MUTATIONS=true npx mocha -r ts-node/register --extensions ts 'test/**/*.{test,spec}.ts'"
   },
   "lint-staged": {
     "*": "npx embedme \"*.md\"",

--- a/src/KeyManager.ts
+++ b/src/KeyManager.ts
@@ -40,7 +40,7 @@ export class KeyManager {
           ) as keystore;
           genseed = seedObject.seed;
         } else {
-          genseed = Wallet.createRandom().privateKey;
+          genseed = this.generateRandomSeed();
           fs.writeFileSync(keyStorePath, JSON.stringify({ seed: genseed }), {
             flag: 'w',
           });
@@ -56,7 +56,7 @@ export class KeyManager {
     } else {
       // no workdir: working in-memory
       if (seed == null) {
-        seed = Wallet.createRandom().privateKey;
+        seed = this.generateRandomSeed();
       }
       this._hdkey = utils.HDNode.fromSeed(seed ?? Buffer.from(''));
     }
@@ -64,7 +64,11 @@ export class KeyManager {
     this.generateKeys(count);
   }
 
-  generateKeys(count: number): void {
+  private generateRandomSeed() {
+    return Buffer.from(utils.randomBytes(16).buffer).toString('hex');
+  }
+
+  private generateKeys(count: number): void {
     this._privateKeys = {};
     this._nonces = {};
     for (let index = 0; index < count; index++) {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,5 +2,5 @@
   "extends": "./tsconfig.json",	
   "exclude": [	
     "test"	
-  ]	
+  ]
 }	


### PR DESCRIPTION
## What

- create random seed using randomBytes rather than the private key of a random wallet

## Why

-  to avoid reduced entropy
