### PR TITLE
fix(RREL-17): use rpc accounts for dev purposes only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "prettier": "^2.8.3",
         "sinon": "^15.0.1",
         "ts-node": "^10.9.1",
+        "tsconfig-paths": "^4.2.0",
         "typescript": "4.8.2"
       }
     },
@@ -12822,6 +12823,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -13353,6 +13363,20 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tslib": {
@@ -23861,6 +23885,12 @@
         "ansi-regex": "^5.0.1"
       }
     },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true
+    },
     "strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -24245,6 +24275,17 @@
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
           "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
         }
+      }
+    },
+    "tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "requires": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
       }
     },
     "tslib": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "register": "ts-node src/commands/Register.ts",
     "start": "ts-node src/commands/Start.ts",
     "tdd": "npm run test -- --watch --watch-files src,test",
-    "test": "ALLOW_CONFIG_MUTATIONS=true npx mocha -r ts-node/register --extensions ts 'test/**/*.{test,spec}.ts'"
+    "test": "ALLOW_CONFIG_MUTATIONS=true npx mocha -r ts-node/register -r tsconfig-paths/register --extensions ts 'test/**/*.{test,spec}.ts'"
   },
   "lint-staged": {
     "*": "npx embedme \"*.md\"",
@@ -121,6 +121,7 @@
     "prettier": "^2.8.3",
     "sinon": "^15.0.1",
     "ts-node": "^10.9.1",
+    "tsconfig-paths": "^4.2.0",
     "typescript": "4.8.2"
   }
 }

--- a/src/commands/findWealthyAccount.ts
+++ b/src/commands/findWealthyAccount.ts
@@ -1,0 +1,36 @@
+import type { JsonRpcProvider } from '@ethersproject/providers';
+import { BigNumber, Signer, utils } from 'ethers';
+import log from 'loglevel';
+
+export const REGTEST_CHAIN_ID = 33;
+
+export const findWealthyAccount = async (
+  rpcProvider: JsonRpcProvider,
+  requiredBalance: BigNumber = utils.parseUnits('2', 'ether')
+): Promise<Signer> => {
+  const { chainId } = await rpcProvider.getNetwork();
+  if (chainId !== REGTEST_CHAIN_ID) {
+    throw new Error('Unlocked accounts are allowed for testing purposes only');
+  }
+
+  let accounts: string[] = [];
+  try {
+    accounts = await rpcProvider.listAccounts();
+    for (let i = 0; i < accounts.length; i++) {
+      const signer = rpcProvider.getSigner(i);
+      const balance = await signer.getBalance();
+      if (balance.gte(requiredBalance)) {
+        log.info(`Found funded account ${await signer.getAddress()}`);
+
+        return signer;
+      }
+    }
+  } catch (error) {
+    log.error('Failed to retrieve accounts and balances:', error);
+  }
+  throw new Error(
+    `could not find unlocked account with sufficient balance; all accounts:\n - ${accounts.join(
+      '\n - '
+    )}`
+  );
+};

--- a/test/unit/findWealthAccounts.spec.ts
+++ b/test/unit/findWealthAccounts.spec.ts
@@ -1,0 +1,55 @@
+import { expect, use } from 'chai';
+import { utils, type providers } from 'ethers';
+import {
+  REGTEST_CHAIN_ID,
+  findWealthyAccount,
+} from 'src/commands/findWealthyAccount';
+import chaiAsPromised from 'chai-as-promised';
+
+use(chaiAsPromised);
+
+const TESTNET_CHAIN_ID = 31;
+const MAINNET_CHAIN_ID = 30;
+
+describe.only('findWealthAccounts', function () {
+  const expectedSigner = {
+    getAddress: () => '0x123abc',
+    getBalance: () => Promise.resolve(utils.parseUnits('2', 'ether')),
+  };
+
+  const getMockedProvider = (expectedChainId: number) =>
+    ({
+      getNetwork: () => ({ chainId: expectedChainId }),
+      listAccounts: () => [1, 2, 3],
+      getSigner: () => expectedSigner,
+    } as unknown as providers.JsonRpcProvider);
+
+  const expectFindWealthyAccountToFail = async (chainId: number) => {
+    const mockRpcProvider = getMockedProvider(chainId);
+    await expect(findWealthyAccount(mockRpcProvider)).to.rejectedWith(
+      'Unlocked accounts are allowed for testing purposes only'
+    );
+  };
+
+  it('should not raise an error if it is used for dev purposes', async function () {
+    const mockRpcProvider = getMockedProvider(REGTEST_CHAIN_ID);
+    const account = await findWealthyAccount(mockRpcProvider);
+    expect(account).to.be.eq(expectedSigner);
+  });
+
+  it('should raise an error if it is not used on Testnet', async function () {
+    await expectFindWealthyAccountToFail(TESTNET_CHAIN_ID);
+  });
+
+  it('should raise an error if it is not used on Mainnet', async function () {
+    await expectFindWealthyAccountToFail(MAINNET_CHAIN_ID);
+  });
+
+  it('should raise an error if no accounts are found with enough balance', async function() {
+    const mockRpcProvider = getMockedProvider(REGTEST_CHAIN_ID);
+    await expect(findWealthyAccount(mockRpcProvider, utils.parseUnits('3', 'ether'))).to.rejectedWith(
+      'could not find unlocked account with sufficient balance;'
+    );
+  })
+
+});

--- a/test/unit/findWealthAccounts.spec.ts
+++ b/test/unit/findWealthAccounts.spec.ts
@@ -11,7 +11,7 @@ use(chaiAsPromised);
 const TESTNET_CHAIN_ID = 31;
 const MAINNET_CHAIN_ID = 30;
 
-describe.only('findWealthAccounts', function () {
+describe('findWealthAccounts', function () {
   const expectedSigner = {
     getAddress: () => '0x123abc',
     getBalance: () => Promise.resolve(utils.parseUnits('2', 'ether')),
@@ -45,11 +45,12 @@ describe.only('findWealthAccounts', function () {
     await expectFindWealthyAccountToFail(MAINNET_CHAIN_ID);
   });
 
-  it('should raise an error if no accounts are found with enough balance', async function() {
+  it('should raise an error if no accounts are found with enough balance', async function () {
     const mockRpcProvider = getMockedProvider(REGTEST_CHAIN_ID);
-    await expect(findWealthyAccount(mockRpcProvider, utils.parseUnits('3', 'ether'))).to.rejectedWith(
+    await expect(
+      findWealthyAccount(mockRpcProvider, utils.parseUnits('3', 'ether'))
+    ).to.rejectedWith(
       'could not find unlocked account with sufficient balance;'
     );
-  })
-
+  });
 });

--- a/test/unit/findWealthAccounts.spec.ts
+++ b/test/unit/findWealthAccounts.spec.ts
@@ -37,11 +37,11 @@ describe('findWealthAccounts', function () {
     expect(account).to.be.eq(expectedSigner);
   });
 
-  it('should raise an error if it is not used on Testnet', async function () {
+  it('should raise an error if it is used on Testnet', async function () {
     await expectFindWealthyAccountToFail(TESTNET_CHAIN_ID);
   });
 
-  it('should raise an error if it is not used on Mainnet', async function () {
+  it('should raise an error if it is used on Mainnet', async function () {
     await expectFindWealthyAccountToFail(MAINNET_CHAIN_ID);
   });
 


### PR DESCRIPTION
## What

- check that RPC accounts are used on Regtest only

## Why

- The wallet installed on the RSK node accessible via RPC is not secure 
