### PR TITLE
PP-816: do not wait for replenishment when relaying a tx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "mocha": "^10.2.0",
         "prettier": "^2.8.3",
         "sinon": "^15.0.1",
+        "sinon-chai": "^3.7.0",
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^4.2.0",
         "typescript": "4.8.2"
@@ -11889,6 +11890,16 @@
         "url": "https://opencollective.com/sinon"
       }
     },
+    "node_modules/sinon-chai": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
+      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
+      "dev": true,
+      "peerDependencies": {
+        "chai": "^4.0.0",
+        "sinon": ">=4.0.0"
+      }
+    },
     "node_modules/sinon/node_modules/diff": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
@@ -23190,6 +23201,13 @@
           "dev": true
         }
       }
+    },
+    "sinon-chai": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
+      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
+      "dev": true,
+      "requires": {}
     },
     "slash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "mocha": "^10.2.0",
     "prettier": "^2.8.3",
     "sinon": "^15.0.1",
+    "sinon-chai": "^3.7.0",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",
     "typescript": "4.8.2"

--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "lint": "npx eslint --cache \"{,test/**/}*.ts\" \"{,src/**/}*.ts\"",
     "lint:fix": "npm run lint -- --fix",
     "prepare": "scripts/prepare",
-    "register": "ts-node src/commands/Register.ts",
-    "start": "ts-node src/commands/Start.ts",
+    "register": "ts-node -r tsconfig-paths/register src/commands/Register.ts",
+    "start": "ts-node -r tsconfig-paths/register src/commands/Start.ts",
     "tdd": "npm run test -- --watch --watch-files src,test",
     "test": "ALLOW_CONFIG_MUTATIONS=true npx mocha -r ts-node/register -r tsconfig-paths/register --extensions ts 'test/**/*.{test,spec}.ts'"
   },

--- a/src/RelayServer.ts
+++ b/src/RelayServer.ts
@@ -64,8 +64,10 @@ import {
 } from './relayServerUtils';
 import { getPastEventsForHub } from './getPastEventsForHub';
 import type { PastEventOptions } from './definitions';
-import { EVENT_REPLENISH_CHECK_REQUIRED } from './events/checkReplenish';
-import { registerEventHandlers } from './events';
+import {
+  EVENT_REPLENISH_CHECK_REQUIRED,
+  registerEventHandlers,
+} from './events';
 
 const VERSION = '2.0.1';
 

--- a/src/ReplenishFunction.ts
+++ b/src/ReplenishFunction.ts
@@ -19,6 +19,13 @@ type BalanceRefill = {
 const notifyBalanceRefill = (message: string, balanceRefill: BalanceRefill) =>
   notify(message, { ...balanceRefill });
 
+/**
+ * It withdraws excess balance from the relayHub to the relayManager, and refills the relayWorker with
+ * balance if required.
+ * @param relayServer The currently running instance of the relay server
+ * @param workerIndex Not used so it can be any number
+ * @param currentBlock Where to place the replenish action
+ */
 export async function replenishStrategy(
   relayServer: RelayServer,
   workerIndex: number,

--- a/src/events/checkReplenish.ts
+++ b/src/events/checkReplenish.ts
@@ -1,0 +1,22 @@
+import type { RelayServer } from 'src/RelayServer';
+import { replenishStrategy } from 'src/ReplenishFunction';
+import log from 'loglevel';
+
+export const EVENT_REPLENISH_CHECK_REQUIRED = 'REPLENISH_CHECK_REQUIRED';
+
+export const checkReplenish = (
+  relayServer: RelayServer,
+  workerIndex: number,
+  currentBlock: number
+) => {
+  replenishStrategy(relayServer, workerIndex, currentBlock)
+    .then((txHashes) => {
+      if (txHashes && txHashes.length) {
+        log.info(`checkReplenish: Server replenished`, txHashes);
+
+        return;
+      }
+      log.info(`checkReplenish: Replenishment wasn't required`);
+    })
+    .catch((err) => log.error(`checkReplenish: Error while replenishing the server`, err));
+};

--- a/src/events/checkReplenish.ts
+++ b/src/events/checkReplenish.ts
@@ -18,5 +18,7 @@ export const checkReplenish = (
       }
       log.info(`checkReplenish: Replenishment wasn't required`);
     })
-    .catch((err) => log.error(`checkReplenish: Error while replenishing the server`, err));
+    .catch((err) =>
+      log.error(`checkReplenish: Error while replenishing the server`, err)
+    );
 };

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,9 +1,11 @@
 import type { RelayServer } from 'src/RelayServer';
 import {
-  EVENT_REPLENISH_CHECK_REQUIRED,
+  EVENT_REPLENISH_CHECK_REQUIRED as replenishCheckRequiredEvent,
   checkReplenish,
 } from './checkReplenish';
 
 export const registerEventHandlers = (relayServer: RelayServer) => {
-  relayServer.on(EVENT_REPLENISH_CHECK_REQUIRED, checkReplenish);
+  relayServer.on(replenishCheckRequiredEvent, checkReplenish);
 };
+
+export const EVENT_REPLENISH_CHECK_REQUIRED = replenishCheckRequiredEvent;

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,0 +1,9 @@
+import type { RelayServer } from 'src/RelayServer';
+import {
+  EVENT_REPLENISH_CHECK_REQUIRED,
+  checkReplenish,
+} from './checkReplenish';
+
+export const registerEventHandlers = (relayServer: RelayServer) => {
+  relayServer.on(EVENT_REPLENISH_CHECK_REQUIRED, checkReplenish);
+};


### PR DESCRIPTION

## What

- add an event handler to check if the server needs to be replenished

## Why

- if an error occurs during the replenishment, the user gets an error and this could be misleading

## Refs

- RREL-0019
