### PR TITLE
build: avoid pointing to the src folder in the built files

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "lint": "npx eslint --cache \"{,test/**/}*.ts\" \"{,src/**/}*.ts\"",
     "lint:fix": "npm run lint -- --fix",
     "prepare": "scripts/prepare",
-    "register": "ts-node -r tsconfig-paths/register src/commands/Register.ts",
-    "start": "ts-node -r tsconfig-paths/register src/commands/Start.ts",
+    "register": "ts-node src/commands/Register.ts",
+    "start": "ts-node src/commands/Start.ts",
     "tdd": "npm run test -- --watch --watch-files src,test",
     "test": "ALLOW_CONFIG_MUTATIONS=true npx mocha -r ts-node/register -r tsconfig-paths/register --extensions ts 'test/**/*.{test,spec}.ts'"
   },

--- a/src/events/checkReplenish.ts
+++ b/src/events/checkReplenish.ts
@@ -1,5 +1,5 @@
-import type { RelayServer } from 'src/RelayServer';
-import { replenishStrategy } from 'src/ReplenishFunction';
+import type { RelayServer } from '../RelayServer';
+import { replenishStrategy } from '../ReplenishFunction';
 import log from 'loglevel';
 
 export const EVENT_REPLENISH_CHECK_REQUIRED = 'REPLENISH_CHECK_REQUIRED';

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,4 +1,4 @@
-import type { RelayServer } from 'src/RelayServer';
+import type { RelayServer } from '../RelayServer';
 import {
   EVENT_REPLENISH_CHECK_REQUIRED as replenishCheckRequiredEvent,
   checkReplenish,


### PR DESCRIPTION
## What

-  avoid pointing to the src folder in the built files

## Why

- the built files doesn't have the `src` folder hence they won't be able to run properly
