### PR TITLE
PP-830: change package name to include org

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "rif-relay-server",
+  "name": "@rsksmart/rif-relay-server",
   "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "rif-relay-server",
+      "name": "@rsksmart/rif-relay-server",
       "version": "2.2.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rif-relay-server",
+  "name": "@rsksmart/rif-relay-server",
   "version": "2.2.0",
   "private": false,
   "description": "This project contains all the server code for the rif relay system.",


### PR DESCRIPTION
## What

-   Change package name to include `@rsksmart`

## Why

-  Because when we install it using the github URL, it gets installed as `rif-relay-server` instead of `@rsksmart/rif-relay-server`