### PR TITLE
ci: Add the env config for rwt2

### DIFF
--- a/config/rwt2.json5
+++ b/config/rwt2.json5
@@ -1,0 +1,20 @@
+{
+  app: {
+    url: "https://relay2.rif-wallet-services.testnet.rifcomputing.net",
+    port: 8090,
+    devMode: true,
+    logLevel: 0,
+    disableSponsoredTx: false,
+    gasFeePercentage: "0",
+    workdir: "/srv/app/environment",
+  },
+  blockchain: {
+    rskNodeUrl: "http://172.17.0.1:4444",
+  },
+  contracts: {
+    relayHubAddress: "0xAd525463961399793f8716b0D85133ff7503a7C2",
+    relayVerifierAddress: "0xB86c972Ff212838C4c396199B27a0DBe45560df8",
+    deployVerifierAddress: "0xc67f193Bb1D64F13FD49E2da6586a2F417e56b16",
+    feesReceiver: "0x52D107bB12d83EbCBFb4A6Ad0ec866Bb69FdB5Db",
+  }
+}


### PR DESCRIPTION
## What

- Allow the RIF Wallet team to use a new environment to test v2 of the server

## Why

- Before migrating, they want to perform some tests.
