### PR TITLE
PP-838: update relay client dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "@rsksmart/rif-relay-client": "^2.0.0",
+        "@rsksmart/rif-relay-client": "^2.1.0",
         "@rsksmart/rif-relay-contracts": "2.0.0-beta.1",
         "async-mutex": "^0.4.0",
         "async-retry": "^1.3.3",
@@ -2072,9 +2072,9 @@
       "integrity": "sha512-z0zMCjyhhp4y7XKAcDAi3Vgms4T2PstwBdahiO0+9NaGICQKjynK3wduSRplTgk4LXmoO1yfDGO5RbjKYxtuxA=="
     },
     "node_modules/@rsksmart/rif-relay-client": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rif-relay-client/-/rif-relay-client-2.0.0.tgz",
-      "integrity": "sha512-9lgRf6Q4tCoy3rCVeyqx/0ZN406SyM2gePsPd76ricj5IVKGboj8XpBjf/mPLogoEXVcOsHZ4O28P+tU9HuofA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rif-relay-client/-/rif-relay-client-2.1.0.tgz",
+      "integrity": "sha512-6KygFmwDSOA287ENrectEqqdZ+AbMWOpSUU+USacI+I32WeHSsCZwlhGh8aHdygKMcns4DRxJ7xFWxpIFdIUgw==",
       "dependencies": {
         "bignumber.js": "^9.1.1",
         "loglevel": "~1.8.0",
@@ -15687,9 +15687,9 @@
       "integrity": "sha512-z0zMCjyhhp4y7XKAcDAi3Vgms4T2PstwBdahiO0+9NaGICQKjynK3wduSRplTgk4LXmoO1yfDGO5RbjKYxtuxA=="
     },
     "@rsksmart/rif-relay-client": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rif-relay-client/-/rif-relay-client-2.0.0.tgz",
-      "integrity": "sha512-9lgRf6Q4tCoy3rCVeyqx/0ZN406SyM2gePsPd76ricj5IVKGboj8XpBjf/mPLogoEXVcOsHZ4O28P+tU9HuofA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rif-relay-client/-/rif-relay-client-2.1.0.tgz",
+      "integrity": "sha512-6KygFmwDSOA287ENrectEqqdZ+AbMWOpSUU+USacI+I32WeHSsCZwlhGh8aHdygKMcns4DRxJ7xFWxpIFdIUgw==",
       "requires": {
         "bignumber.js": "^9.1.1",
         "loglevel": "~1.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rif-relay-server",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rif-relay-server",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@rsksmart/rif-relay-client": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "package.json": "npx sort-package-json"
   },
   "dependencies": {
-    "@rsksmart/rif-relay-client": "^2.0.0",
+    "@rsksmart/rif-relay-client": "^2.1.0",
     "@rsksmart/rif-relay-contracts": "2.0.0-beta.1",
     "async-mutex": "^0.4.0",
     "async-retry": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rif-relay-server",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": false,
   "description": "This project contains all the server code for the rif relay system.",
   "license": "MIT",


### PR DESCRIPTION
## What

-  Use the latest version of the rif-relay-client

## Why

- To support USDRIF
