### PR TITLE
PP-815: update docs to clarify security aspects

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -156,8 +156,8 @@ File [./config/default.json5](config/default.json5) contains all configuration p
   register: {
     stake: "0.01", // amount of stake to set up
     funds: "0.02", // amount of funds to set up
-    mnemonic: "", // mnemonic to use for unlocking the account parameter
-    privateKey: "", // private key to retrieve the account address from
+    mnemonic: "", // mnemonic to use for unlocking the account parameter; DO NOT STORE IT HERE, use REGISTER_MNEMONIC as env variable. 
+    privateKey: "", // private key to retrieve the account address from; DO NOT STORE IT HERE, use REGISTER_PRIVATE_KEY as env variable. 
     relayHub: "",
     gasPrice: 60000000,
     unstakeDelay: 1000,
@@ -207,6 +207,10 @@ Some of these options will be overrideable using environment variables defined i
 }
 
 ```
+
+> ### :warning: Warning
+>
+> Keep in mind that neither `mnemonic` or `privateKey` are intended to be set in the file directly and doing it can lead to security issues. Please refer to the [server registration section](#server-registration) for further details.
 
 </details>
 

--- a/Readme.md
+++ b/Readme.md
@@ -283,7 +283,7 @@ Relayer state: READY
 >
 > Keep in mind that there are different ways to specify the keys during the registration steps.
 > 1. If nothing is specified, the register scrips tries to retrieve the signer from the RPC accounts configured in the node; this method is enabled for development purposes only (Regtest)
-> 2. The user could use either a private key or a mnemonic using the [custom environment variable method](#overrides) hence by specifying `REGISTER_PRIVATE_KEY` or `REGISTER_MNEMONIC` as environment variables (e.g.: `REGISTER_PRIVATE_KEY=0xabc123 npm run register` or `REGISTER_MNEMONIC=0xabc123 npm run register`).
+> 2. The user could use either a private key or a mnemonic using the [custom environment variable method](#overrides) hence by specifying `REGISTER_PRIVATE_KEY` or `REGISTER_MNEMONIC` as environment variables (e.g.: `REGISTER_PRIVATE_KEY="0xabc123" npm run register` or `REGISTER_MNEMONIC="word1 word2 etc..." npm run register`).
 
 ### Execute as a Docker container
 

--- a/Readme.md
+++ b/Readme.md
@@ -275,6 +275,12 @@ After this you will see several log entries indicating the registration progress
 Relayer state: READY
 ```
 
+> ### :warning: Warning
+>
+> Keep in mind that there are different ways to specify the keys during the registration steps.
+> 1. If nothing is specified, the register scrips tries to retrieve the signer from the RPC accounts configured in the node; this method is enabled for development purposes only (Regtest)
+> 2. The user could use either a private key or a mnemonic using the [custom environment variable method](https://github.com/rsksmart/rif-relay-server/blob/main/Readme.md#overrides) hence by specifying `REGISTER_PRIVATE_KEY` or `REGISTER_MNEMONIC` as environment variables (e.g.: `REGISTER_PRIVATE_KEY=0xabc123 npm run register` or `REGISTER_MNEMONIC=0xabc123 npm run register`).
+
 ### Execute as a Docker container
 
 You can run the server as a Docker container. Docker and Docker compose should be installed and an RSK Node should be running.

--- a/Readme.md
+++ b/Readme.md
@@ -283,7 +283,7 @@ Relayer state: READY
 >
 > Keep in mind that there are different ways to specify the keys during the registration steps.
 > 1. If nothing is specified, the register scrips tries to retrieve the signer from the RPC accounts configured in the node; this method is enabled for development purposes only (Regtest)
-> 2. The user could use either a private key or a mnemonic using the [custom environment variable method](https://github.com/rsksmart/rif-relay-server/blob/main/Readme.md#overrides) hence by specifying `REGISTER_PRIVATE_KEY` or `REGISTER_MNEMONIC` as environment variables (e.g.: `REGISTER_PRIVATE_KEY=0xabc123 npm run register` or `REGISTER_MNEMONIC=0xabc123 npm run register`).
+> 2. The user could use either a private key or a mnemonic using the [custom environment variable method](#overrides) hence by specifying `REGISTER_PRIVATE_KEY` or `REGISTER_MNEMONIC` as environment variables (e.g.: `REGISTER_PRIVATE_KEY=0xabc123 npm run register` or `REGISTER_MNEMONIC=0xabc123 npm run register`).
 
 ### Execute as a Docker container
 

--- a/config/default.json5
+++ b/config/default.json5
@@ -94,8 +94,8 @@
   register: {
     stake: "0.01", // amount of stake to set up
     funds: "0.02", // amount of funds to set up
-    mnemonic: "", // mnemonic to use for unlocking the account parameter
-    privateKey: "", // private key to retrieve the account address from
+    mnemonic: "", // mnemonic to use for unlocking the account parameter; DO NOT STORE IT HERE, use REGISTER_MNEMONIC as env variable. 
+    privateKey: "", // private key to retrieve the account address from; DO NOT STORE IT HERE, use REGISTER_PRIVATE_KEY as env variable. 
     relayHub: "",
     gasPrice: 60000000,
     unstakeDelay: 1000,

--- a/src/commands/Register.ts
+++ b/src/commands/Register.ts
@@ -192,7 +192,8 @@ executeRegister()
     log.info('Registration is done!');
   })
   .catch((error) => {
-    log.info('Error registering relay server', error);
+    // we don't use the log library here because an error could be raised before setting the log level.
+    console.error('Error registering relay server', error);
   });
 
 export type { RegisterOptions, RegisterConfig };


### PR DESCRIPTION
## What

- update docs

## Why

- to clarify keys usage on registration (RREL-0017)
- to clarify that `mnemonic` and `privateKey` are not intended to be used in clear in the json files.
