### PR TITLE
PP-842: fix resending underpriced transactions 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rsksmart/rif-relay-server",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rsksmart/rif-relay-server",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "@rsksmart/rif-relay-client": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-relay-server",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "private": false,
   "description": "This project contains all the server code for the rif relay system.",
   "license": "MIT",

--- a/src/TransactionManager.ts
+++ b/src/TransactionManager.ts
@@ -441,8 +441,8 @@ data         | 0x${transaction.data ?? ''}
       );
 
       //TODO check if there is no issue with the type conversion
-      const underpricedTransactions = sortedTxs.filter(
-        (it) => it.gasPrice && it.gasPrice < newGasPrice
+      const underpricedTransactions = sortedTxs.filter((it) =>
+        it.gasPrice?.lt(newGasPrice)
       );
       for (const transaction of underpricedTransactions) {
         const boostedTransactionDetails = await this.resendTransaction(

--- a/src/TransactionManager.ts
+++ b/src/TransactionManager.ts
@@ -440,7 +440,6 @@ data         | 0x${transaction.data ?? ''}
         oldestPendingTx.gasPrice
       );
 
-      //TODO check if there is no issue with the type conversion
       const underpricedTransactions = sortedTxs.filter((it) =>
         it.gasPrice?.lt(newGasPrice)
       );

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,0 @@
-export const SERVER_VERSION = "2.2.0";

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,1 @@
+export const SERVER_VERSION = "2.2.0";


### PR DESCRIPTION
## What

- fix parsing of `BigNumber` from local db
- fix `BigNumber` comparison using the `.lt` operator instead of `<`

## Why

- `gasPrice` and `gasLimit` were not properly parsed from the database
- `gasPrice` was compared using the `<` operator
