### PR TITLE
DEVOPS-1891: Implement CICD for Boltz Testnet

### DIFF
--- a/.github/workflows/deploy.boltz.testnet.yml
+++ b/.github/workflows/deploy.boltz.testnet.yml
@@ -4,7 +4,9 @@ name: CD for Boltz Testnet
 on:
     push:
         tags:
-            - '**beta-boltz-testnet**'
+            - '**beta-boltz**'
+        branches: [ DEVOPS-1891/add-ci-for-boltz ]
+
 
 jobs:
     deploy-testnet:

--- a/.github/workflows/deploy.boltz.testnet.yml
+++ b/.github/workflows/deploy.boltz.testnet.yml
@@ -9,7 +9,7 @@ on:
 
 
 jobs:
-    deploy-testnet:
+    deploy-boltz-testnet:
         runs-on: ubuntu-latest
         environment:
             name: Boltz-Testnet

--- a/.github/workflows/deploy.boltz.testnet.yml
+++ b/.github/workflows/deploy.boltz.testnet.yml
@@ -25,12 +25,12 @@ jobs:
               with:
                   aws-access-key-id: ${{ secrets.BOLTZ_TESTNET_AWS_ACCESS_KEY_ID }}
                   aws-secret-access-key: ${{ secrets.BOLTZ_TESTNET_AWS_SECRET_ACCESS_KEY }}
-                  aws-region: ${{ secrets.BOLTZ_TESTNET_AWS_REGION }}
+                  aws-region: "us-west-2"
 
             - name: Deploy rif-relay-server on Boltz Testnet
               run: |
                   aws ssm send-command \
                       --document-name "AWS-RunRemoteScript" \
                       --instance-ids ""${{ secrets.BOLTZ_TESTNET_EC2_ID }}"" \
-                      --region=${{ secrets.BOLTZ_TESTNET_AWS_REGION }} \
+                      --region="us-west-2" \
                       --parameters '{"sourceType":["GitHub"],"sourceInfo":["{\"owner\":\"rootstock\", \"repository\":\"ask-devops\", \"path\": \"rif-relay/\", \"tokenInfo\":\"{{ssm-secure:github-token}}\"}"],"commandLine":["deploy-testnet.sh"]}'

--- a/.github/workflows/deploy.boltz.testnet.yml
+++ b/.github/workflows/deploy.boltz.testnet.yml
@@ -1,0 +1,34 @@
+---
+name: CD for Boltz Testnet
+
+on:
+    push:
+        tags:
+            - '**beta-boltz-testnet**'
+
+jobs:
+    deploy-testnet:
+        runs-on: ubuntu-latest
+        environment:
+            name: Boltz-Testnet
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v1
+              with:
+                  aws-access-key-id: ${{ secrets.BOLTZ_TESTNET_AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.BOLTZ_TESTNET_AWS_SECRET_ACCESS_KEY }}
+                  aws-region: ${{ secrets.BOLTZ_TESTNET_AWS_REGION }}
+
+            - name: Deploy rif-relay-server on TESTNET
+              run: |
+                  aws ssm send-command \
+                      --document-name "AWS-RunRemoteScript" \
+                      --instance-ids ""${{ secrets.BOLTZ_TESTNET_EC2_ID }}"" \
+                      --region=${{ secrets.BOLTZ_TESTNET_AWS_REGION }} \
+                      --parameters '{"sourceType":["GitHub"],"sourceInfo":["{\"owner\":\"rootstock\", \"repository\":\"ask-devops\", \"path\": \"rif-relay/\", \"tokenInfo\":\"{{ssm-secure:github-token}}\"}"],"commandLine":["deploy-testnet.sh"]}'

--- a/.github/workflows/deploy.boltz.testnet.yml
+++ b/.github/workflows/deploy.boltz.testnet.yml
@@ -25,12 +25,12 @@ jobs:
               with:
                   aws-access-key-id: ${{ secrets.BOLTZ_TESTNET_AWS_ACCESS_KEY_ID }}
                   aws-secret-access-key: ${{ secrets.BOLTZ_TESTNET_AWS_SECRET_ACCESS_KEY }}
-                  aws-region: "us-west-2"
+                  aws-region: "${{ secrets.BOLTZ_TESTNET_AWS_REGION }}"
 
             - name: Deploy rif-relay-server on Boltz Testnet
               run: |
                   aws ssm send-command \
                       --document-name "AWS-RunRemoteScript" \
                       --instance-ids ""${{ secrets.BOLTZ_TESTNET_EC2_ID }}"" \
-                      --region="us-west-2" \
+                      --region=${{ secrets.BOLTZ_TESTNET_AWS_REGION }} \
                       --parameters '{"sourceType":["GitHub"],"sourceInfo":["{\"owner\":\"rootstock\", \"repository\":\"ask-devops\", \"path\": \"rif-relay/\", \"tokenInfo\":\"{{ssm-secure:github-token}}\"}"],"commandLine":["deploy-testnet.sh"]}'

--- a/.github/workflows/deploy.boltz.testnet.yml
+++ b/.github/workflows/deploy.boltz.testnet.yml
@@ -25,7 +25,7 @@ jobs:
                   aws-secret-access-key: ${{ secrets.BOLTZ_TESTNET_AWS_SECRET_ACCESS_KEY }}
                   aws-region: ${{ secrets.BOLTZ_TESTNET_AWS_REGION }}
 
-            - name: Deploy rif-relay-server on TESTNET
+            - name: Deploy rif-relay-server on Boltz Testnet
               run: |
                   aws ssm send-command \
                       --document-name "AWS-RunRemoteScript" \

--- a/.github/workflows/deploy.boltz.testnet.yml
+++ b/.github/workflows/deploy.boltz.testnet.yml
@@ -5,7 +5,6 @@ on:
     push:
         tags:
             - '**beta-boltz**'
-        branches: [ DEVOPS-1891/add-ci-for-boltz ]
 
 
 jobs:


### PR DESCRIPTION
## What

-   Implement CD for Boltz Instance running Relay

## Why

-   Necessary to execute CD as we have for other relay environments (dev, qa, rwm and rwt)

## Refs

-   https://rsklabs.atlassian.net/browse/DEVOPS-1891
