### PR TITLE
fix(RREL-026): avoid using PromiseOrValue type in server

### DIFF
--- a/src/HttpEnvelopingRequest.ts
+++ b/src/HttpEnvelopingRequest.ts
@@ -1,7 +1,4 @@
-import type {
-  Either,
-  Modify,
-} from '@rsksmart/rif-relay-client/dist/common/utility.types';
+import type { Either } from '@rsksmart/rif-relay-client/dist/common/utility.types';
 import type { BigNumberish } from 'ethers';
 import type {
   RelayRequestBody as ClientRelayRequestBody,
@@ -11,40 +8,11 @@ import type {
 // IMPORTANT: The types defined here mirror the types defined in the client.
 //            see EnvelopingTxRequest in the rif-relay-client library
 
-export declare type RelayRequestBody = Modify<
-  ClientRelayRequestBody,
-  {
-    relayHub: string;
-    from: string;
-    to: string;
-    tokenContract: string;
-    value: BigNumberish;
-    gas: BigNumberish;
-    nonce: BigNumberish;
-    tokenAmount: BigNumberish;
-    tokenGas: BigNumberish;
-    validUntilTime: BigNumberish;
-    data: string;
-  }
->;
+type Await<T> = { [P in keyof T]: Awaited<T[P]> };
 
-export declare type DeployRequestBody = Modify<
-  ClientDeployRequestBody,
-  {
-    relayHub: string;
-    from: string;
-    to: string;
-    tokenContract: string;
-    recoverer: string;
-    value: BigNumberish;
-    nonce: BigNumberish;
-    tokenAmount: BigNumberish;
-    tokenGas: BigNumberish;
-    validUntilTime: BigNumberish;
-    index: BigNumberish;
-    data: string;
-  }
->;
+export declare type RelayRequestBody = Await<ClientRelayRequestBody>;
+
+export declare type DeployRequestBody = Await<ClientDeployRequestBody>;
 
 export declare type EnvelopingMetadata = {
   relayHubAddress: RelayRequestBody['relayHub'];

--- a/src/HttpEnvelopingRequest.ts
+++ b/src/HttpEnvelopingRequest.ts
@@ -1,0 +1,70 @@
+import type {
+  Either,
+  Modify,
+} from '@rsksmart/rif-relay-client/dist/common/utility.types';
+import type { BigNumberish } from 'ethers';
+import type {
+  RelayRequestBody as ClientRelayRequestBody,
+  DeployRequestBody as ClientDeployRequestBody,
+} from '@rsksmart/rif-relay-client';
+
+// IMPORTANT: The types defined here mirror the types defined in the client.
+//            see EnvelopingTxRequest in the rif-relay-client library
+
+export declare type RelayRequestBody = Modify<
+  ClientRelayRequestBody,
+  {
+    relayHub: string;
+    from: string;
+    to: string;
+    tokenContract: string;
+    value: BigNumberish;
+    gas: BigNumberish;
+    nonce: BigNumberish;
+    tokenAmount: BigNumberish;
+    tokenGas: BigNumberish;
+    validUntilTime: BigNumberish;
+    data: string;
+  }
+>;
+
+export declare type DeployRequestBody = Modify<
+  ClientDeployRequestBody,
+  {
+    relayHub: string;
+    from: string;
+    to: string;
+    tokenContract: string;
+    recoverer: string;
+    value: BigNumberish;
+    nonce: BigNumberish;
+    tokenAmount: BigNumberish;
+    tokenGas: BigNumberish;
+    validUntilTime: BigNumberish;
+    index: BigNumberish;
+    data: string;
+  }
+>;
+
+export declare type EnvelopingMetadata = {
+  relayHubAddress: RelayRequestBody['relayHub'];
+  relayMaxNonce: number;
+  signature: string;
+};
+
+export declare type EnvelopingRequestData = {
+  gasPrice: BigNumberish;
+  feesReceiver: string;
+  callForwarder: string;
+  callVerifier: string;
+};
+
+export declare type EnvelopingRequest = {
+  request: Either<RelayRequestBody, DeployRequestBody>;
+  relayData: EnvelopingRequestData;
+};
+
+export declare type HttpEnvelopingRequest = {
+  relayRequest: EnvelopingRequest;
+  metadata: EnvelopingMetadata;
+};

--- a/src/HttpServer.ts
+++ b/src/HttpServer.ts
@@ -1,4 +1,3 @@
-import type { EnvelopingTxRequest } from '@rsksmart/rif-relay-client';
 import bodyParser from 'body-parser';
 import cors from 'cors';
 import express, { Express, Request, Response } from 'express';
@@ -8,6 +7,7 @@ import jsonrpc, { Defined } from 'jsonrpc-lite';
 import log from 'loglevel';
 import configureDocumentation from './DocConfiguration';
 import type { RelayServer } from './RelayServer';
+import type { HttpEnvelopingRequest } from './HttpEnvelopingRequest';
 
 export type RootHandlerRequestBody = {
   id?: number;
@@ -256,7 +256,7 @@ export class HttpServer {
     try {
       const { signedTx, txHash } =
         await this._relayServer.createRelayTransaction(
-          body as EnvelopingTxRequest
+          body as HttpEnvelopingRequest
         );
       res.send({ signedTx, txHash });
     } catch (e) {
@@ -321,7 +321,7 @@ export class HttpServer {
   async estimateHandler(req: Request, res: Response): Promise<void> {
     try {
       const estimation = await this._relayServer.estimateMaxPossibleGas(
-        req.body as EnvelopingTxRequest
+        req.body as HttpEnvelopingRequest
       );
       res.send(estimation);
     } catch (e) {

--- a/src/HttpServer.ts
+++ b/src/HttpServer.ts
@@ -7,7 +7,7 @@ import jsonrpc, { Defined } from 'jsonrpc-lite';
 import log from 'loglevel';
 import configureDocumentation from './DocConfiguration';
 import type { RelayServer } from './RelayServer';
-import type { HttpEnvelopingRequest } from './HttpEnvelopingRequest';
+import type { HttpEnvelopingRequest } from './definitions/HttpEnvelopingRequest';
 
 export type RootHandlerRequestBody = {
   id?: number;

--- a/src/RelayServer.ts
+++ b/src/RelayServer.ts
@@ -69,7 +69,7 @@ import {
   registerEventHandlers,
 } from './events';
 import { SERVER_VERSION as version } from './version';
-import type { HttpEnvelopingRequest } from './HttpEnvelopingRequest';
+import type { HttpEnvelopingRequest } from './definitions/HttpEnvelopingRequest';
 
 type HubInfo = {
   relayWorkerAddress: string;
@@ -259,19 +259,22 @@ export class RelayServer extends EventEmitter {
   }
 
   async validateInput(envelopingRequest: HttpEnvelopingRequest): Promise<void> {
-    const { metadata, relayRequest } = envelopingRequest;
+    const {
+      metadata: { relayHubAddress: relayHubAddressFromRequest },
+      relayRequest,
+    } = envelopingRequest;
 
     const {
       app: { requestMinValidSeconds },
       contracts: { relayHubAddress },
     } = this.config;
 
-    const relayHubAddressValue = metadata.relayHubAddress;
-
     // Check that the relayHub is the correct one
-    if (relayHubAddressValue.toLowerCase() !== relayHubAddress.toLowerCase()) {
+    if (
+      relayHubAddressFromRequest.toLowerCase() !== relayHubAddress.toLowerCase()
+    ) {
       throw new Error(
-        `Wrong hub address.\nRelay server's hub address: ${this.config.contracts.relayHubAddress}, request's hub address: ${relayHubAddressValue}\n`
+        `Wrong hub address.\nRelay server's hub address: ${this.config.contracts.relayHubAddress}, request's hub address: ${relayHubAddressFromRequest}\n`
       );
     }
 

--- a/src/definitions/HttpEnvelopingRequest.ts
+++ b/src/definitions/HttpEnvelopingRequest.ts
@@ -8,11 +8,11 @@ import type {
 // IMPORTANT: The types defined here mirror the types defined in the client.
 //            see EnvelopingTxRequest in the rif-relay-client library
 
-type Await<T> = { [P in keyof T]: Awaited<T[P]> };
+type AwaitedWrapper<T> = { [P in keyof T]: Awaited<T[P]> };
 
-export declare type RelayRequestBody = Await<ClientRelayRequestBody>;
+export declare type RelayRequestBody = AwaitedWrapper<ClientRelayRequestBody>;
 
-export declare type DeployRequestBody = Await<ClientDeployRequestBody>;
+export declare type DeployRequestBody = AwaitedWrapper<ClientDeployRequestBody>;
 
 export declare type EnvelopingMetadata = {
   relayHubAddress: RelayRequestBody['relayHub'];

--- a/src/relayServerUtils.ts
+++ b/src/relayServerUtils.ts
@@ -30,7 +30,7 @@ import type {
   EnvelopingRequest,
   HttpEnvelopingRequest,
   RelayRequestBody,
-} from './HttpEnvelopingRequest';
+} from './definitions/HttpEnvelopingRequest';
 
 const TRANSFER_HASH = 'a9059cbb';
 const TRANSFER_FROM_HASH = '23b872dd';

--- a/test/unit/RelayServer.test.ts
+++ b/test/unit/RelayServer.test.ts
@@ -5,7 +5,6 @@ import {
   TxStoreManager,
 } from '../../src';
 import sinon, { SinonSpy, SinonStub, createStubInstance } from 'sinon';
-import type { EnvelopingTxRequest } from '@rsksmart/rif-relay-client';
 import * as rifClient from '@rsksmart/rif-relay-client';
 import { BigNumber, constants, providers, utils } from 'ethers';
 import * as serverUtils from '../../src/Utils';
@@ -21,6 +20,7 @@ import {
 } from 'src/events/checkReplenish';
 import * as replenish from 'src/ReplenishFunction';
 import sinonChai from 'sinon-chai';
+import type { HttpEnvelopingRequest } from 'src/HttpEnvelopingRequest';
 
 use(sinonChai);
 use(chaiAsPromised);
@@ -155,7 +155,7 @@ describe('RelayServer tests', function () {
             gasPrice: GAS_PRICE,
           },
         },
-      } as unknown as EnvelopingTxRequest);
+      } as unknown as HttpEnvelopingRequest);
       expect(onSpy).to.have.been.calledWith(
         EVENT_REPLENISH_CHECK_REQUIRED,
         relayServer,
@@ -200,7 +200,7 @@ describe('RelayServer tests', function () {
             gasPrice: GAS_PRICE,
           },
         },
-      } as unknown as EnvelopingTxRequest);
+      } as unknown as HttpEnvelopingRequest);
       expect(signedTx).to.be.eql(expectedTransactionDetails);
       expect(replenishStub).to.have.been.calledOnce;
     });
@@ -220,7 +220,7 @@ describe('RelayServer tests', function () {
               gasPrice: GAS_PRICE,
             },
           },
-        } as EnvelopingTxRequest
+        } as HttpEnvelopingRequest
       );
 
       expect(maxPossibleGasEstimation.estimation).to.be.equal(
@@ -243,7 +243,7 @@ describe('RelayServer tests', function () {
               gasPrice: GAS_PRICE,
             },
           },
-        } as EnvelopingTxRequest
+        } as HttpEnvelopingRequest
       );
 
       expect(maxPossibleGasEstimation.estimation).to.eq(
@@ -273,7 +273,7 @@ describe('RelayServer tests', function () {
             gasPrice: GAS_PRICE,
           },
         },
-      } as EnvelopingTxRequest);
+      } as HttpEnvelopingRequest);
 
       expect(maxPossibleGasWithFee.toString()).to.be.equal(
         FAKE_ESTIMATION_BEFORE_FEES.toString()
@@ -294,7 +294,7 @@ describe('RelayServer tests', function () {
             gasPrice: GAS_PRICE,
           },
         },
-      } as EnvelopingTxRequest);
+      } as HttpEnvelopingRequest);
 
       expect(maxPossibleGasWithFee.toString()).to.eq(
         BigNumberJs(FAKE_ESTIMATION_BEFORE_FEES)
@@ -320,7 +320,7 @@ describe('RelayServer tests', function () {
             gasPrice: GAS_PRICE,
           },
         },
-      } as EnvelopingTxRequest);
+      } as HttpEnvelopingRequest);
 
       const { maxPossibleGasWithFee } = await relayServer.getMaxPossibleGas({
         relayRequest: {
@@ -331,7 +331,7 @@ describe('RelayServer tests', function () {
             gasPrice: GAS_PRICE,
           },
         },
-      } as EnvelopingTxRequest);
+      } as HttpEnvelopingRequest);
 
       expect(estimatedGas.estimation.toString()).to.be.eq(
         maxPossibleGasWithFee.toString()

--- a/test/unit/RelayServer.test.ts
+++ b/test/unit/RelayServer.test.ts
@@ -20,7 +20,7 @@ import {
 } from 'src/events/checkReplenish';
 import * as replenish from 'src/ReplenishFunction';
 import sinonChai from 'sinon-chai';
-import type { HttpEnvelopingRequest } from 'src/HttpEnvelopingRequest';
+import type { HttpEnvelopingRequest } from 'src/definitions/HttpEnvelopingRequest';
 
 use(sinonChai);
 use(chaiAsPromised);

--- a/test/unit/relayServerUtils.test.ts
+++ b/test/unit/relayServerUtils.test.ts
@@ -25,7 +25,7 @@ import type {
   EnvelopingRequest,
   EnvelopingRequestData,
   RelayRequestBody,
-} from 'src/HttpEnvelopingRequest';
+} from 'src/definitions/HttpEnvelopingRequest';
 
 const ZERO_ADDRESS = constants.AddressZero;
 const FAKE_ESTIMATION_BEFORE_FEES = 100000;

--- a/test/unit/relayServerUtils.test.ts
+++ b/test/unit/relayServerUtils.test.ts
@@ -1,9 +1,4 @@
 import sinon, { SinonStub } from 'sinon';
-import type {
-  RelayRequestBody,
-  EnvelopingRequestData,
-  RelayRequest,
-} from '@rsksmart/rif-relay-client';
 import { BigNumber, constants } from 'ethers';
 import {
   ERC20__factory,
@@ -26,6 +21,11 @@ import chaiAsPromised from 'chai-as-promised';
 import * as relayServerUtils from '../../src/relayServerUtils';
 import * as relayClient from '@rsksmart/rif-relay-client';
 import type { AppConfig } from 'src';
+import type {
+  EnvelopingRequest,
+  EnvelopingRequestData,
+  RelayRequestBody,
+} from 'src/HttpEnvelopingRequest';
 
 const ZERO_ADDRESS = constants.AddressZero;
 const FAKE_ESTIMATION_BEFORE_FEES = 100000;
@@ -37,8 +37,8 @@ const FAKE_FIXED_USD_FEE = 2;
 const TOKEN_AMOUNT_TO_TRANSFER = '1000000000000000000'; //18 zeros
 const TOKEN_VALUE_IN_USD = 0.5;
 
-function createRequest(request: Partial<RelayRequestBody>): RelayRequest {
-  const baseRequest: RelayRequest = {
+function createRequest(request: Partial<RelayRequestBody>): EnvelopingRequest {
+  const baseRequest: EnvelopingRequest = {
     request: {
       relayHub: ZERO_ADDRESS,
       from: ZERO_ADDRESS,
@@ -58,7 +58,7 @@ function createRequest(request: Partial<RelayRequestBody>): RelayRequest {
       callForwarder: ZERO_ADDRESS,
       callVerifier: ZERO_ADDRESS,
     } as EnvelopingRequestData,
-  } as RelayRequest;
+  } as EnvelopingRequest;
 
   return {
     request: {
@@ -68,7 +68,7 @@ function createRequest(request: Partial<RelayRequestBody>): RelayRequest {
     relayData: {
       ...baseRequest.relayData,
     },
-  };
+  } as EnvelopingRequest;
 }
 
 use(chaiAsPromised);


### PR DESCRIPTION
## What

-  do not use the type defined in the client to avoid `PromiseOrValue` type
- redefine the same types in the server without using `PromiseOrValue`.

## Why

-  that type is defined from ethers and it may be misleading because when receiving the request from the server, the values will never be promises
