### PR TITLE
feat: update to use iam roles (oidc), no longer access keys

### DIFF
--- a/.github/workflows/deploy.boltz.testnet.yml
+++ b/.github/workflows/deploy.boltz.testnet.yml
@@ -20,10 +20,9 @@ jobs:
                   fetch-depth: 0
 
             - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v1
+              uses: aws-actions/configure-aws-credentials@v4
               with:
-                  aws-access-key-id: ${{ secrets.BOLTZ_TESTNET_AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.BOLTZ_TESTNET_AWS_SECRET_ACCESS_KEY }}
+                  role-to-assume: ${{ secrets.BOLTZ_TESTNET_ROLE_ARN }}
                   aws-region: "${{ secrets.BOLTZ_TESTNET_AWS_REGION }}"
 
             - name: Deploy rif-relay-server on Boltz Testnet

--- a/.github/workflows/deploy.qa.yml
+++ b/.github/workflows/deploy.qa.yml
@@ -18,10 +18,9 @@ jobs:
                   fetch-depth: 0
 
             - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v1
+              uses: aws-actions/configure-aws-credentials@v4
               with:
-                  aws-access-key-id: ${{ secrets.QA_AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.QA_AWS_SECRET_ACCESS_KEY }}
+                  role-to-assume: ${{ secrets.QA_ROLE_ARN }}
                   aws-region: ${{ secrets.QA_AWS_REGION }}
 
             - name: Deploy rif-relay-server on QA

--- a/.github/workflows/deploy.rwm.yml
+++ b/.github/workflows/deploy.rwm.yml
@@ -19,10 +19,9 @@ jobs:
                   fetch-depth: 0
 
             - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v1
+              uses: aws-actions/configure-aws-credentials@v4
               with:
-                  aws-access-key-id: ${{ secrets.RWM_AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.RWM_AWS_SECRET_ACCESS_KEY }}
+                  role-to-assume: ${{ secrets.RWM_ROLE_ARN }}
                   aws-region: ${{ secrets.RWM_AWS_REGION }}
 
             - name: Deploy rif-relay-server on RIF-Wallet Mainnet

--- a/.github/workflows/deploy.rwt.yml
+++ b/.github/workflows/deploy.rwt.yml
@@ -19,10 +19,9 @@ jobs:
                   fetch-depth: 0
 
             - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v1
+              uses: aws-actions/configure-aws-credentials@v4
               with:
-                  aws-access-key-id: ${{ secrets.RWT_AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.RWT_AWS_SECRET_ACCESS_KEY }}
+                  role-to-assume: ${{ secrets.RWT_ROLE_ARN }}
                   aws-region: ${{ secrets.RWT_AWS_REGION }}
 
             - name: Deploy rif-relay-server on RWT

--- a/.github/workflows/deploy.testnet.yml
+++ b/.github/workflows/deploy.testnet.yml
@@ -19,10 +19,9 @@ jobs:
                   fetch-depth: 0
 
             - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v1
+              uses: aws-actions/configure-aws-credentials@v4
               with:
-                  aws-access-key-id: ${{ secrets.TESTNET_AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.TESTNET_AWS_SECRET_ACCESS_KEY }}
+                  role-to-assume: ${{ secrets.TESTNET_ROLE_ARN }}
                   aws-region: ${{ secrets.TESTNET_AWS_REGION }}
 
             - name: Deploy rif-relay-server on TESTNET


### PR DESCRIPTION
## What

-  We no longer use aws access and secret keys in CICD

## Why

-   Security Reasons, It's safer to use ROLES which are attached and can only be used with it's assigned repository.

## Refs

-   OKR goals
