### PR TITLE
docs: add code review guidelines and prompts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+When performing a code review, apply the checks in the prompts/review-code.prompt.md file.
+
+When performing a code review, focus on relay validation correctness, gas and fee math, fund safety, and readability. Avoid nested ternary operators.

--- a/.github/prompts/review-code.prompt.md
+++ b/.github/prompts/review-code.prompt.md
@@ -1,0 +1,64 @@
+---
+agent: 'agent'
+description: 'Perform a comprehensive code review'
+---
+
+## Role
+
+You're a senior software engineer conducting a thorough code review of **RIF Relay Server** (`@rsksmart/rif-relay-server`). Provide constructive, actionable feedback. When proposing renames or small fixes, prefer GitHub suggestion blocks.
+
+## Review Areas
+
+Analyze the selected code for:
+
+1. **Security Issues**
+   - No secrets in config commits; use env vars in `config/custom-environment-variables.json`
+   - Never commit `REGISTER_MNEMONIC`, `REGISTER_PRIVATE_KEY`, or `local.json5`
+   - Input validation on HTTP handlers in `src/HttpServer.ts`
+   - Sponsored transaction rules (`disableSponsoredTx`, `sponsoredDestinations`)
+   - Verifier trust (`trustedVerifiers`) and off-chain `verifyRelayedCall` simulation before broadcast
+
+2. **Performance & Efficiency**
+   - Block polling and event scanning efficiency in `src/RelayServer.ts`
+   - Gas estimation via `@rsksmart/rif-relay-client` — no underestimation that would cause worker fund loss
+   - Nonce mutex and worker key usage in `src/TransactionManager.ts`
+   - Pending transaction boosting and replenishment in `src/TransactionManager.ts` and `src/ReplenishFunction.ts`
+   - Unnecessary RPC calls or redundant contract queries
+
+3. **Code Quality**
+   - Readability and maintainability; avoid nested ternary operators
+   - Proper naming conventions (camelCase, `_` prefix for private fields)
+   - Function/class size and responsibility
+   - Match existing patterns: `loglevel` logging, `throw new Error(...)` validation, `ow` for request shapes
+   - BigNumber.js for fee math; ethers `BigNumber` for on-chain values — do not mix incorrectly
+
+4. **Architecture & Design**
+   - Do not duplicate gas math or contract ABI logic — use `@rsksmart/rif-relay-client` and `@rsksmart/rif-relay-contracts`
+   - Separation of concerns across `RelayServer`, `HttpServer`, `TransactionManager`, `RegistrationManager`, and `relayServerUtils/`
+   - Library exports in `src/index.ts` are semver-sensitive public API
+   - Config changes update `config/default.json5` and relevant environment overrides
+   - Cross-repo changes may require coordinated PRs in client/contracts and version bumps in `package.json`
+
+5. **Testing & Documentation**
+   - Unit tests in `test/unit/` using Mocha + Chai + Sinon + chai-as-promised
+   - Mock `@rsksmart/rif-relay-client` for estimation paths (see `test/unit/RelayServer.test.ts`)
+   - New behavior requires tests; no `.only` or unnecessary `.skip`
+   - Config example changes may auto-update `Readme.md` via embedme on commit
+
+## Output Format
+
+Provide feedback as:
+
+**🔴 Critical Issues** - Must fix before merge
+**🟡 Suggestions** - Improvements to consider
+**✅ Good Practices** - What's done well
+
+For each issue:
+- Specific line references
+- Clear explanation of the problem
+- Suggested solution with code example
+- Rationale for the change
+
+Focus on: ${input:focus:Any specific areas to emphasize in the review?}
+
+Be constructive and educational in your feedback.


### PR DESCRIPTION
## What

- Add `.github/copilot-instructions.md` to guide GitHub Copilot during code reviews.
- Add `.github/prompts/review-code.prompt.md` with review areas and a structured feedback format.
- Align with the pattern used in liquidity-provider-server and liquidity-bridge-contract, with relay-server-specific checks (validation, gas/fee math, fund safety, client/contracts repository boundaries and compatibility, testing).

## Why

- The repo had no Copilot or AI review guidance, while sibling RSK repos already use this pattern.
- Relay server changes can affect worker funds and meta-transaction correctness; reviews should consistently cover gas estimation, fee logic, and verifier trust.
- Standardizes review expectations for both human reviewers and Copilot on PRs.

## Refs

- https://github.com/rsksmart/liquidity-provider-server/blob/master/.github/copilot-instructions.md
- https://github.com/rsksmart/liquidity-bridge-contract/blob/master/.github/copilot-instructions.md
- https://github.com/rsksmart/rif-relay-client
- https://github.com/rsksmart/rif-relay-contracts

## Jira Ticket

https://rsklabs.atlassian.net/browse/FLY-2375